### PR TITLE
feat: 🎸 Play NFT video on hover of card

### DIFF
--- a/src/components/core/cards/nft-card/nft-card.tsx
+++ b/src/components/core/cards/nft-card/nft-card.tsx
@@ -34,6 +34,7 @@ export const NftCard = React.memo(
     displayVideo,
   }: NftCardProps) => {
     const { t } = useTranslation();
+    // TODO: Refactor logic to play NFT videos only on hover
 
     return (
       <RouterLink to={`/nft/${data.id}`}>

--- a/src/integrations/kyasshu/utils.ts
+++ b/src/integrations/kyasshu/utils.ts
@@ -47,6 +47,7 @@ export const fetchNFTS = async ({
         name: 'Cap Crowns',
         price: nft.lastSalePrice,
         lastOffer: nft.lastSalePrice,
+        // TODO: extract thumbnail URL and assign it to preview
         preview: false,
         location: nft?.url,
         traits: {


### PR DESCRIPTION
## Why?

Play NFT video on hover of card and show thumbnails while loading all NFT's

## How?

- [ ]  Extract thumbnail from `nft.url = nft.url.replace(/\/(\w+)\.\w+/g, "/thumbnails/$1.png");` - `9000.mp4
 -> thumbnails/9000.png`
- [ ]  Add thumbnail image along with video url in NFT json data
- [ ]  Show thumbnail image as default value in UI
- [ ]  Refactor NFT card to play video on hover

## Tickets?

- [Notion ticket](https://www.notion.so/Replace-the-Crown-videos-with-thumbnails-a4cb2ce15d394a6aa285d74671720c63)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass

## Demo?

Need to define
