### PR TITLE
chore: 🤖 disable eslint no unused prop types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
   "rules": {
     "no-use-before-define": "off",
     "no-param-reassign": 0,
+    "react/no-unused-prop-types": false,
     "@typescript-eslint/no-use-before-define": ["error"],
     "react/jsx-filename-extension": [
       "warn",


### PR DESCRIPTION
## Why?

On the latest in develop, there are a bunch of eslint errors, which seems to be a bit too strict. If required, then this should be addressed separately.

