### PR TITLE
fix: 🐛 warning, use 0 instead of false

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
   "rules": {
     "no-use-before-define": "off",
     "no-param-reassign": 0,
-    "react/no-unused-prop-types": false,
+    "react/no-unused-prop-types": 0,
     "@typescript-eslint/no-use-before-define": ["error"],
     "react/jsx-filename-extension": [
       "warn",


### PR DESCRIPTION
## Why?

There's a warning msg, as false is not supported
