### PR TITLE
chore: 🤖 icp market price

### DIFF
--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -10,6 +10,8 @@ import {
   AccordionHeadContent,
   FlexRight,
   PlugButtonWrapper,
+  UndefinedPrice,
+  OffersCount,
 } from './styles';
 import offer from '../../../assets/accordions/offer.svg';
 import offerDark from '../../../assets/accordions/offer-dark.svg';
@@ -20,15 +22,20 @@ import arrowup from '../../../assets/accordions/arrow-up.svg';
 import arrowupDark from '../../../assets/accordions/arrow-up-dark.svg';
 import { OffersTable } from '../../tables';
 import { Plug } from '../../plug';
-import {
-  getICPPrice,
-  getCurrentMarketPrice,
-} from '../../../integrations/marketplace/price.utils';
+import { getCurrentMarketPrice } from '../../../integrations/marketplace/price.utils';
 
-export const OfferAccordion = () => {
-  // TODO: Get the current price from endpoint/service
-  const currentListForSalePrice = 100;
+export type OfferAccordionProps = {
+  lastSalePrice?: string;
+  isListed?: boolean;
+};
+
+export const OfferAccordion = ({
+  lastSalePrice,
+  isListed,
+}: OfferAccordionProps) => {
   const { t } = useTranslation();
+  // TODO: update offers count
+  const totalOffers = 5;
   const [isAccordionOpen, setIsAccordionOpen] = useState(true);
   const [marketPrice, setMarketPrice] = useState<
     string | undefined
@@ -42,17 +49,21 @@ export const OfferAccordion = () => {
   const { isConnected } = usePlugStore();
 
   useEffect(() => {
+    if (!lastSalePrice || !isListed) return;
+
     (async () => {
       // TODO: On loading and awaiting for coin gecko response
       // should display a small loader in the place of price
 
       const formattedPrice = await getCurrentMarketPrice({
-        currentListForSalePrice,
+        currentListForSalePrice: Number(lastSalePrice),
       });
 
       setMarketPrice(formattedPrice);
     })();
-  }, []);
+  }, [lastSalePrice, isListed]);
+
+  const isListedWithPrice = isListed && lastSalePrice;
 
   return (
     <AccordionStyle type="single" collapsible width="medium">
@@ -66,7 +77,11 @@ export const OfferAccordion = () => {
                   'translation:accordions.offer.header.currentPrice',
                 )}
               </span>
-              <h4>{`${currentListForSalePrice} WICP`}</h4>
+              <h4>
+                {(isListedWithPrice && `${lastSalePrice} WICP`) || (
+                  <UndefinedPrice>--</UndefinedPrice>
+                )}
+              </h4>
             </div>
           </FlexRight>
           <h3>{marketPrice}</h3>
@@ -91,18 +106,23 @@ export const OfferAccordion = () => {
             />
             <p>
               {`${t('translation:accordions.offer.header.offer')}`}
+              <OffersCount>
+                {`(${(isListed && totalOffers) || 0})`}
+              </OffersCount>
             </p>
           </div>
-          <img
-            src={!isAccordionOpen ? arrowupTheme : arrowdownTheme}
-            alt="arrow-down"
-          />
+          {isListed && (
+            <img
+              src={!isAccordionOpen ? arrowupTheme : arrowdownTheme}
+              alt="arrow-down"
+            />
+          )}
         </AccordionTrigger>
         <AccordionContent
           padding="none"
           backgroundColor={isAccordionOpen ? 'notopen' : 'open'}
         >
-          <OffersTable />
+          {isListed && <OffersTable />}
         </AccordionContent>
       </Accordion.Item>
     </AccordionStyle>

--- a/src/components/core/accordions/styles.ts
+++ b/src/components/core/accordions/styles.ts
@@ -274,3 +274,12 @@ export const PlugButtonWrapper = styled('div', {
     marginLeft: '0px',
   },
 });
+
+export const UndefinedPrice = styled('div', {
+  fontSize: '32px',
+  color: '$greyMid',
+});
+
+export const OffersCount = styled('div', {
+  marginLeft: '5px',
+});

--- a/src/components/modals/sell-modal.tsx
+++ b/src/components/modals/sell-modal.tsx
@@ -59,7 +59,12 @@ export const SellModal = () => {
 
     // Update NFT listed for sale in store
     // on successful listing and closing the modal
-    dispatch(nftsActions.setNFTForSale(id));
+    dispatch(
+      nftsActions.setNFTForSale({
+        id,
+        amount,
+      }),
+    );
   };
 
   const handleModalClose = () => {

--- a/src/components/nft-details/nft-details.tsx
+++ b/src/components/nft-details/nft-details.tsx
@@ -76,7 +76,10 @@ export const NftDetails = () => {
           </PreviewContainer>
           <DetailsContainer>
             <NFTMetaData id={nftDetails.id} />
-            <OfferAccordion />
+            <OfferAccordion
+              lastSalePrice={nftDetails?.price}
+              isListed={nftDetails?.isListed}
+            />
             <AboutAccordion owned />
           </DetailsContainer>
         </Wrapper>

--- a/src/integrations/kyasshu/utils.ts
+++ b/src/integrations/kyasshu/utils.ts
@@ -117,8 +117,8 @@ export const fetchNFTDetails = async ({
       // TODO: Finalize object format after validating mock and kyasshu data
       id: responseData.index,
       name: 'Cap Crowns',
-      price: '',
-      lastOffer: '',
+      price: responseData?.lastSalePrice,
+      lastOffer: responseData?.lastOfferPrice,
       // TODO: update nft thumbnail
       preview: '',
       location: responseData?.url,

--- a/src/integrations/marketplace/price.utils.ts
+++ b/src/integrations/marketplace/price.utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import axios from 'axios';
 
 const COINGECKO_ICP_ID = 'internet-computer';

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -108,7 +108,7 @@
     },
     "offer": {
       "header": {
-        "offer": "Offers (12)",
+        "offer": "Offers",
         "currentPrice": "Current Price"
       }
     }

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -36,6 +36,7 @@ export const {
       skeletonBackground:
         'linear-gradient(90deg, rgb(229, 232, 235) 0%, rgb(247, 248, 250) 59.9%)',
       checkboxSelectedFiltersText: '#23262F',
+      greyMid: '#767D8E',
     },
     space: {},
     fonts: {},

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -30,6 +30,11 @@ interface loadedNFTData {
   nextPage: number;
 }
 
+interface listedNFTData {
+  id: string;
+  amount: string;
+}
+
 export const nftsSlice = createSlice({
   name: 'nfts',
   // `createSlice` will infer the state type from the `initialState` argument
@@ -77,8 +82,8 @@ export const nftsSlice = createSlice({
 
       state.loadedNFTS.push(action.payload);
     },
-    setNFTForSale: (state, action: PayloadAction<string>) => {
-      const id = action.payload;
+    setNFTForSale: (state, action: PayloadAction<listedNFTData>) => {
+      const { id, amount } = action.payload;
       const index = state.loadedNFTS.findIndex(
         (nft) => nft.id === id,
       );
@@ -86,6 +91,7 @@ export const nftsSlice = createSlice({
       if (index < 0) return;
 
       state.loadedNFTS[index].isListed = true;
+      state.loadedNFTS[index].price = amount;
     },
   },
 });


### PR DESCRIPTION
## Why?

The ICP price should be provided by the market price.

## How?

- Provides a utility method, similar to Plug ( https://github.com/Psychedelic/plug/blob/e9148c229f646caae44b178b44655b96405627a5/source/shared/services/ICPPrice.js )
- Use locale

## Contribution checklist?

- [x ] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass

⚠️ Note that I've worked without the linter, as its currently triggering a bunch of errors on my machine, will check my setup Friday.

## Demo?

The price is based in locale, my case England, which formats as US$xxx

<img width="1028" alt="Screenshot 2022-03-24 at 19 15 14" src="https://user-images.githubusercontent.com/236752/159993305-fd02c318-c12f-48be-8fdf-7e42e06ea4e7.png">

