### PR TITLE
refactor: 💡 search modal background dark mode

### DIFF
--- a/src/components/search/styles.ts
+++ b/src/components/search/styles.ts
@@ -165,7 +165,7 @@ export const WICPText = styled('div', {
   fontSize: '16px',
   fontWeight: '600',
   lineHeight: '20px',
-  color: '#23262F',
+  color: '$mainTextColor',
 
   // variants
   variants: {


### PR DESCRIPTION
## Why?

Addressed feedback on the search modal colors when dark mode is selected.

## How?

- Added respective variables to their style properties

## Tickets?

- [Ticket 1](the-ticket-url-here)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/160951426-6535a9be-3597-48ca-96f2-115a9238fe85.mov


