### PR TITLE
Fix: 🔨 Button Height Uniformity

### DIFF
--- a/src/components/core/buttons/styles.ts
+++ b/src/components/core/buttons/styles.ts
@@ -76,9 +76,9 @@ export const LinkButtonStyles = styled('a', {
   variants: {
     type: {
       textBtn: {
-        padding: '8px 12px',
+        padding: '0px 12px',
         width: 'initial',
-        height: 'initial',
+        height: '40px',
       },
     },
   },


### PR DESCRIPTION
## Why?

To fix website button height which appears smaller than the social ones.

## How?

- Added fixed height to text button
- Removed top and bottom padding

## Tickets?

- [Notion](https://www.notion.so/Feedback_Royce-28-March-cd8d3cdbc3cd4169983868c3807dceb2?p=3d7f7eb532ab4af69406920968620f49)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="302" alt="Screenshot 2022-04-01 at 11 14 34" src="https://user-images.githubusercontent.com/51888121/161244133-5921780f-e961-4745-8f46-c8bab7bb9b56.png">

