### PR TITLE
refactor: 💡 Refactored Table Text Link

### DIFF
--- a/src/components/core/table-cells/styles.ts
+++ b/src/components/core/table-cells/styles.ts
@@ -179,6 +179,7 @@ export const TextLinkDetails = styled('a', {
   lineHeight: '20px',
   color: '#2253FF',
   textDecoration: 'none',
+  cursor: 'pointer',
 
   variants: {
     type: {

--- a/src/components/core/table-cells/text-link-cell.tsx
+++ b/src/components/core/table-cells/text-link-cell.tsx
@@ -13,7 +13,8 @@ export const TextLinkCell = ({
   url,
   type,
 }: TextLinkCellProps) => (
-  <TextLinkDetails type={type} href={url} target="_blank">
+  // TO-DO: Pass in correct route
+  <TextLinkDetails type={type} target="_blank">
     {text}
   </TextLinkDetails>
 );


### PR DESCRIPTION
## Why?

Fixed links in the history table in the PVP (product view page) pointing to the same page.

## How?

- Modified styles
- Removed `url` prop with the empty string causing rerouting

## Tickets?

- [Notion](https://www.notion.so/Feedback_Nacho-28-March-ef79bc3feeb040e694db674400008465?p=c0fb8f627bd14b729e06a588a3108bc2)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/161243287-7b3ea4f0-d202-4f5c-8c80-1188882310f4.mov
