### PR TITLE
style: 💅🏼 stacked about accordion header

### DIFF
--- a/src/components/core/accordions/styles.ts
+++ b/src/components/core/accordions/styles.ts
@@ -32,6 +32,7 @@ export const AccordionHead = styled('div', {
   display: 'flex',
   justifyContent: 'space-between',
   padding: '30px 25px',
+  flexWrap: 'wrap',
 
   // variants
   variants: {
@@ -45,6 +46,7 @@ export const AccordionHead = styled('div', {
 
 export const AccordionHeadContent = styled('div', {
   display: 'flex',
+  marginBottom: '10px',
 
   variants: {
     flexProperties: {


### PR DESCRIPTION
## Why?

Wrap content on smaller screens.

## How?

- Added a flex-wrap property to the styles component

## Tickets?

- [Notion](https://www.notion.so/Feedback_Royce-28-March-cd8d3cdbc3cd4169983868c3807dceb2?p=6f9f8c87147a41d88de59f3d033db475)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/161500720-ad29e595-0c56-4aaf-8c12-ca5fb03b83d4.mov


