### PR TITLE
fix: 🔨 route to all nfts on click of clear filters

### DIFF
--- a/src/components/filters/filters.tsx
+++ b/src/components/filters/filters.tsx
@@ -132,6 +132,7 @@ export const Filters = () => {
                     onClick={() => {
                       dispatch(filterActions.clearAllFilters());
                       dispatch(settingsActions.setPriceApplyButton(false));
+                      dispatch(filterActions.setMyNfts(false));
                     }}
                   >
                     {`${t('translation:filters.clearAll')}`}


### PR DESCRIPTION
## Why?

Route to `All Nfts` after selecting the `Clear All` button.

## How?

- Dispatched an action call that routes to `All Nfts` on click.

## Tickets?

- [Notion](https://www.notion.so/Michael-UI-Feedback_28-March-911c0faad29e4c3b8222cb2d713abdda?p=f60f9e6fb2644f8ea97036bce22c1adb)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/162072320-2d7f3743-4b5e-4d8f-b9fd-1663b0815b36.mov


