### PR TITLE
fix: 🔨 remove double last price + replace with id

### DIFF
--- a/src/components/core/cards/nft-card/nft-card.tsx
+++ b/src/components/core/cards/nft-card/nft-card.tsx
@@ -16,6 +16,7 @@ import {
   PreviewImage,
   VideoLoader,
   ActionText,
+  NftId,
 } from './styles';
 import { NFTMetadata } from '../../../../declarations/nft';
 import wicpLogo from '../../../../assets/wicpIcon.png';
@@ -60,12 +61,9 @@ export const NftCard = React.memo(
               {notForSale ? (
                 ''
               ) : (
-                <LastOffer>
-                  {forSaleAndOffer
-                    ? `${t('translation:nftCard.offerFor')} `
-                    : `${t('translation:nftCard.last')} `}
-                  <b>{data?.lastOffer}</b>
-                </LastOffer>
+                <NftId>
+                  {data?.id}
+                </NftId>
               )}
               {notForSale ? (
                 ''

--- a/src/components/core/cards/nft-card/styles.ts
+++ b/src/components/core/cards/nft-card/styles.ts
@@ -112,7 +112,7 @@ export const NftText = styled('p', {
 
 export const NftId = styled('p', {
   fontStyle: 'normal',
-  fontWeight: '600',
+  fontWeight: '500',
   fontSize: '16px',
   lineHeight: '20px',
   color: '$nftCardId',


### PR DESCRIPTION
## Why?

Removed last price duplicate on nft cards

## How?

- [x]  Removed last price duplicate from nft card
- [x]  Replace with nft id

## Tickets?

- [Notion](https://www.notion.so/Michael-UI-Feedback_28-March-911c0faad29e4c3b8222cb2d713abdda?p=f2455a09acca4eb3978600527e84b565)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-04-06 at 22 15 23" src="https://user-images.githubusercontent.com/51888121/162073003-18d324fc-33d6-4a9e-93f7-7ecefaac82d8.png">
