### PR TITLE
fix: 🔨 Card Image Overlapping Bug

### DIFF
--- a/src/components/core/cards/nft-card/nft-card.tsx
+++ b/src/components/core/cards/nft-card/nft-card.tsx
@@ -17,6 +17,7 @@ import {
   VideoLoader,
   ActionText,
   NftId,
+  MediaWrapper,
 } from './styles';
 import { NFTMetadata } from '../../../../declarations/nft';
 import wicpLogo from '../../../../assets/wicpIcon.png';
@@ -43,16 +44,18 @@ export const NftCard = React.memo(
               </OwnedCardText>
               <CardOptionsDropdown data={data} />
             </Flex>
-            <VideoPlayer
-              videoSrc={data.location}
-              pausedOverlay={
-                // eslint-disable-next-line react/jsx-wrap-multilines
-                <PreviewDetails>
-                  <PreviewImage src={data?.preview} alt="nft-card" />
-                </PreviewDetails>
-              }
-              loadingOverlay={<VideoLoader />}
-            />
+            <MediaWrapper>
+              <VideoPlayer
+                videoSrc={data.location}
+                pausedOverlay={
+                  // eslint-disable-next-line react/jsx-wrap-multilines
+                  <PreviewDetails>
+                    <PreviewImage src={data?.preview} alt="nft-card" />
+                  </PreviewDetails>
+                }
+                loadingOverlay={<VideoLoader />}
+              />
+            </MediaWrapper>
             <Flex>
               <NftText>{data?.name}</NftText>
               <NftText>Price</NftText>

--- a/src/components/core/cards/nft-card/styles.ts
+++ b/src/components/core/cards/nft-card/styles.ts
@@ -33,20 +33,35 @@ export const CardWrapper = styled('div', {
   transition: 'all 0.5s ease-in-out',
 });
 
+export const MediaWrapper = styled('div', {
+  minHeight: '175px',
+
+  '@lg': {
+    height: '270px',
+    width: '100%',
+    marginBottom: '10px',
+  },
+});
+
 export const PreviewDetails = styled('div', {
   minHeight: '175px',
+  width: '100%',
+  height: '100%',
 });
 
 export const PreviewImage = styled('img', {
   width: '100%',
+  height: '100%',
   objectFit: 'cover',
   borderRadius: '14px',
 });
 
 export const VideoPlayer = styled(HoverVideoPlayer, {
   marginBottom: '10px',
+  height: '100%',
+  width: '100%',
   video: {
-    minHeight: '175px',
+    height: '100%',
     borderRadius: '14px',
   },
 });

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -43,7 +43,11 @@ export const {
     space: {},
     fonts: {},
   },
-  media: {},
+  media: {
+    sm: '(max-width: 640px)',
+    md: '(max-width: 1024px)',
+    lg: '(max-width: 1140px)',
+  },
   utils: {},
 });
 


### PR DESCRIPTION
## Why?

NFT Card images overlapped when loaded.

## How?

- Added a wrapper and set a fixed height.

## Tickets?

- [Notion](https://www.notion.so/Remaining-UI-Feedback_28-March-19e646a118304a2b895a5d9dd3239bb5?p=f6ad176eff7443b4bc08125e2130280f)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/163159930-25d65005-2dd8-41c8-a32b-c6207c735ae2.mov


