### PR TITLE
style: 💄 owned should not break card alignment

### DIFF
--- a/src/components/core/cards/nft-card/styles.ts
+++ b/src/components/core/cards/nft-card/styles.ts
@@ -93,13 +93,14 @@ export const Flex = styled('div', {
   },
 });
 
-export const OwnedCardText = styled('p', {
+export const OwnedCardText = styled('span', {
   fontStyle: 'normal',
   fontWeight: '500',
   fontSize: '12px',
   lineHeight: '15px',
   color: '#777E90',
   margin: '0',
+  height: '15px',
 });
 
 export const Dfinity = styled('p', {


### PR DESCRIPTION
Depends on https://github.com/Psychedelic/nft-marketplace-fe/pull/95 which should go first