### PR TITLE
chore: 🤖 on mount, should scroll to the top

### DIFF
--- a/src/views/NFTView/index.tsx
+++ b/src/views/NFTView/index.tsx
@@ -14,6 +14,8 @@ const NFTView = () => {
   const [theme, setTheme] = useState('lightTheme');
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+
     const getTheme = localStorage.getItem('theme');
     if (getTheme) {
       setTheme(getTheme);


### PR DESCRIPTION
## Why?

When a user clicks to view a NFT detail page and the scroll position is not at the top, the position is kept on detail view, when it shouldn't.

## How?

- On detail page scroll to top

