### PR TITLE
fix: 🔨 style issues on chips + flex issue on preview image

### DIFF
--- a/src/components/core/chips/styles.ts
+++ b/src/components/core/chips/styles.ts
@@ -45,12 +45,16 @@ export const TraitChipContainer = styled('div', {
       },
 
       nft: {
-        minWidth: '145px',
+        minWidth: '150px',
         background: '$chipsNftBackgroundColor',
         border: '1.5px solid $borderColor',
         margin: '0px 15px 15px 0px',
       },
     },
+  },
+
+  '&:nth-child(3)': {
+    marginRight: '0px',
   },
 
   '&:last-child': {

--- a/src/components/nft-details/styles.ts
+++ b/src/components/nft-details/styles.ts
@@ -23,8 +23,6 @@ export const Wrapper = styled('div', {
 export const PreviewContainer = styled('div', {
   width: '100%',
   maxWidth: '480px',
-  display: 'flex',
-  flexDirection: 'column',
 });
 
 export const Video = styled('video', {


### PR DESCRIPTION
## Why?

To fix some styling bugs pointed out.

## How?

- Modified width of chips
- Removed flex property on video wrapper

## Tickets?

- [Notion 1](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=de5eecc07119482d9ed7a797e4d4cb97)
- [Notion 2](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=21d9117d4fcf45dc8a0340f83ea41780)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass


## Demo?

Optionally, provide any screenshot, gif or small video.
