### PR TITLE
fix: 🐛 space beneath cards + table multi scroll

### DIFF
--- a/src/components/items/styles.ts
+++ b/src/components/items/styles.ts
@@ -6,6 +6,7 @@ export const Container = styled('div', {
   borderTop: '1px solid $borderColor',
   padding: '0px 80px 80px',
   width: '100%',
+  minHeight: '100vh',
   // borderLeft: '1px solid rgb(229, 232, 235)',
   borderLeft: '1px solid $borderColor',
 });

--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -7,11 +7,9 @@ export const Container = styled('div', {
 });
 
 export const TableWrapper = styled('div', {
-  position: 'relative',
   // marginTop: '44px', // TODO: make variant
   width: '100%',
   height: '100vh',
-  overflowX: 'auto',
 
   table: {
     borderSpacing: '0',
@@ -187,7 +185,6 @@ export const ButtonWrapper = styled('div', {
 export const InfiniteScrollWrapper = styled(InfiniteScroll, {
   width: '100%',
   height: '100vh',
-  overflowX: 'auto',
 });
 
 export const TableSkeletonsWrapper = styled('div', {


### PR DESCRIPTION
## Why?

Allow NFT listing fill available height when filters tab is close.
Remove multi scroll from table and allow it scroll with page

## How?

- Set a min-height property for NFT listing page
- Removed multi-scroll from activity table

## Tickets?

- [Notion 1](https://www.notion.so/Marketplace-Jelly-7f592e9f01494981895b8c84d171b6d1?p=f12b831cd76945cbaf9da8a85cfd666b)
- [Notion 2](https://www.notion.so/There-s-an-accessibility-issue-in-the-Activity-Tab-where-there-s-a-parent-scroll-and-a-child-scr-7be5eb913e534b16bc2a21a109402840)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1153" alt="Screenshot 2022-04-26 at 10 57 21" src="https://user-images.githubusercontent.com/51888121/165363425-82b46f2c-3a78-48cd-96f4-1dc1f573e920.png">

