### PR TITLE
fix: 🐛 accept offer, listing by service is required

### DIFF
--- a/src/store/features/marketplace/marketplace-slice.ts
+++ b/src/store/features/marketplace/marketplace-slice.ts
@@ -213,8 +213,6 @@ export const directBuy = createAsyncThunk<
   const nonFungibleContractAddress = Principal.fromText(config.crownsCanisterId);
   
   try {
-    if (!price) throw Error("Oops! Missing price");
-
     const wicpAmount = BigInt(price);
     const WICP_APPROVE = {
       idl: wicpIdlFactory,


### PR DESCRIPTION
## Why?

At time of writing, havingt the item listed is a requirement by the service. While this seems to be an error in the service, this is added while waiting for PR ( fix: 🐛 accept offer, listing not required #55 https://github.com/Psychedelic/nft-marketplace/pull/55 )

## How?

- Add make listing before accept offer

