### PR TITLE
fix: 🐛 support dark theme in my offers table

### DIFF
--- a/src/components/tables/my-offers-table.tsx
+++ b/src/components/tables/my-offers-table.tsx
@@ -2,12 +2,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import {
-  useThemeStore,
-  useAppDispatch,
-  usePlugStore,
-  RootState,
-} from '../../store';
+import { useAppDispatch, usePlugStore, RootState } from '../../store';
 import {
   ItemDetailsCell,
   PriceDetailsCell,
@@ -48,7 +43,6 @@ export type MyOffersTableProps = {
 export const MyOffersTable = ({ offersType }: MyOffersTableProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const { theme } = useThemeStore();
   const { isConnected } = usePlugStore();
   const [columnsToHide, setColumnsToHide] = useState<Array<string>>(
     [],
@@ -252,7 +246,7 @@ export const MyOffersTable = ({ offersType }: MyOffersTableProps) => {
         ),
       },
     ],
-    [t, theme, columnsToHide], // eslint-disable-line react-hooks/exhaustive-deps
+    [t, columnsToHide], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return (

--- a/src/views/OffersView/styles.ts
+++ b/src/views/OffersView/styles.ts
@@ -3,6 +3,7 @@ import { styled } from '../../stitches.config';
 export const Container = styled('div', {
   width: '100%',
   paddingTop: '72px',
+  backgroundColor: '$backgroundColor',
 });
 
 export const TitleWrapper = styled('div', {


### PR DESCRIPTION
## Why?

Support dark theme in my offers table

## How?

- [x] Added background color to My offers view to support dark theme
- [x] Removed unused code in my offers table

## Demo?

<img width="1435" alt="Screenshot 2022-05-04 at 1 33 28 PM" src="https://user-images.githubusercontent.com/40259256/166643871-5f83d859-b767-4509-9585-514a8b03cabc.png">

