### PR TITLE
fix: 🐛 return type for getBuyerOffers

### DIFF
--- a/src/store/features/marketplace/async-thunks/get-buyer-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-buyer-offers.ts
@@ -9,11 +9,12 @@ import config from '../../../../config/env';
 import { getICPPrice } from '../../../../integrations/marketplace/price.utils';
 import { notificationActions } from '../../errors';
 import { parseOffersMadeResponse } from '../../../../utils/parser';
+import { OffersTableItem } from '../../../../declarations/legacy';
 
 export type GetBuyerOffersProps = DefaultCallbacks & GetBuyerOffers;
 
 export const getBuyerOffers = createAsyncThunk<
-  ReturnType<typeof parseOffersMadeResponse> | undefined,
+  OffersTableItem[] | undefined,
   GetBuyerOffersProps
 >('marketplace/getBuyerOffers', async (params, thunkAPI) => {
   // Checks if an actor instance exists already
@@ -61,6 +62,8 @@ export const getBuyerOffers = createAsyncThunk<
     if (typeof onSuccess !== 'function') return;
 
     onSuccess(parsedTokenOffers);
+
+    return parsedTokenOffers;
   } catch (err) {
     thunkAPI.dispatch(
       notificationActions.setErrorMessage((err as Error).message),


### PR DESCRIPTION
## Why?

Fix return type of get buy offers

