### PR TITLE
fix: 🐛 show loader in cancel offer modal

### DIFF
--- a/src/constants/listing.ts
+++ b/src/constants/listing.ts
@@ -6,4 +6,5 @@ export enum ListingStatusCodes {
   Submitted = 'submitted',
   OfferInfo = 'offerInfo',
   Accepted = 'accepted',
+  CancelOffer = 'cancelOffer',
 }


### PR DESCRIPTION
## Why?

Show loader in cancel offer modal

## How?

- [x] Add cancelOffer constant value in listing codes
- [x] Add modal steps in cancel offer
- [x] Show loader when user clicks cancel offer button in modal

## Demo?



https://user-images.githubusercontent.com/40259256/166871739-d05fb2fd-cf9c-4fb9-b6d8-d9706859470d.mov

