### PR TITLE
refactor: 💡 animate table skeletons

### DIFF
--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -232,7 +232,7 @@ export const ImageSkeleton = styled('div', {
   marginRight: '12px',
   backgroundColor: 'rgba(0, 0, 0, 0.11)',
   background: '$skeletonBackground',
-  animation: `${fadeInOut} 2s linear infinite`,
+  animation: `${fadeInOut} 1.8s linear infinite`,
   transitionTimingFunction: 'ease-in-out',
 });
 
@@ -242,7 +242,7 @@ export const NameSkeleton = styled('div', {
   borderRadius: '10px',
   backgroundColor: 'rgba(0, 0, 0, 0.11)',
   background: '$skeletonBackground',
-  animation: `${fadeInOut} 2s linear infinite`,
+  animation: `${fadeInOut} 1.8s linear infinite`,
   transitionTimingFunction: 'ease-in-out',
 });
 
@@ -259,7 +259,7 @@ export const TypeDetailsSkeleton = styled('div', {
   marginRight: '12px',
   backgroundColor: 'rgba(0, 0, 0, 0.11)',
   background: '$skeletonBackground',
-  animation: `${fadeInOut} 0.2s linear infinite`,
+  animation: `${fadeInOut} 0.1.8s linear infinite`,
 });
 
 export const PriceSkeleton = styled('div', {
@@ -268,7 +268,7 @@ export const PriceSkeleton = styled('div', {
   borderRadius: '10px',
   backgroundColor: 'rgba(0, 0, 0, 0.11)',
   background: '$skeletonBackground',
-  animation: `${fadeInOut} 2s linear infinite`,
+  animation: `${fadeInOut} 1.8s linear infinite`,
   transitionTimingFunction: 'ease-in-out',
 
   '&:nth-child(1)': {
@@ -282,7 +282,7 @@ export const StringSkeleton = styled('div', {
   borderRadius: '10px',
   backgroundColor: 'rgba(0, 0, 0, 0.11)',
   background: '$skeletonBackground',
-  animation: `${fadeInOut} 2s linear infinite`,
+  animation: `${fadeInOut} 1.8s linear infinite`,
   transitionTimingFunction: 'ease-in-out',
 });
 


### PR DESCRIPTION
## Why?

Replace static rendering of skeletons with an animation to avoid it looking like an error

## How?

- Imported `keyframes` from `stitches.config` file
- Added a fade in animation to each skeleton component

## Tickets?

- [Notion](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=8b8022028b78402c862158f08c7ee5fe)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/166894511-77086796-abde-4c1a-89b8-43fbd3fffb68.mov
