### PR TITLE
refactor: 💡 nft card style fixes

### DIFF
--- a/src/components/core/cards/nft-card/styles.ts
+++ b/src/components/core/cards/nft-card/styles.ts
@@ -34,13 +34,14 @@ export const CardWrapper = styled('div', {
   flexDirection: 'column',
   background: '$backgroundColor',
   border: '1.5px solid $borderColor',
+  borderBottom: 'unset',
   boxSizing: 'border-box',
   boxShadow: '0px 0px 8px $navBackgroundColor',
   borderTopRightRadius: '14px',
   borderTopLeftRadius: '14px',
   width: '100%',
   // height: '100%',
-  padding: '10px 0 3px',
+  padding: '0 0 3px',
   cursor: 'pointer',
   transition: 'all 0.5s ease-in-out',
 });
@@ -96,11 +97,16 @@ export const Flex = styled('div', {
   padding: '0 10px 0',
 
   '&:nth-child(1)': {
-    padding: '5px 10px 10px',
+    padding: '7px 10px',
+  },
+
+  '&:nth-child(2)': {
+    padding: 'unset',
+    marginBottom: '4px',
   },
 
   '& p': {
-    margin: '4px 0',
+    margin: '0',
   },
 });
 
@@ -131,15 +137,15 @@ export const Dfinity = styled('p', {
 
 export const NftText = styled('p', {
   fontStyle: 'normal',
-  fontWeight: '500',
-  fontSize: '16px',
+  fontWeight: '400',
+  fontSize: '14px',
   lineHeight: '20px',
-  color: '$nftCardName',
+  color: '#767D8E',
 });
 
 export const NftId = styled('p', {
   fontStyle: 'normal',
-  fontWeight: '500',
+  fontWeight: '600',
   fontSize: '16px',
   lineHeight: '20px',
   color: '$nftCardId',
@@ -179,6 +185,6 @@ export const OuterFlex = styled('div', {
   padding: '3px 10px',
 
   '& p': {
-    margin: '4px 0',
+    margin: '0',
   },
 });

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -59,7 +59,7 @@ export const darkTheme = createTheme({
     borderColor: '#353945',
     buttonsBorderColor: '#777E90',
     nftCardName: '#ffffff',
-    nftCardId: '#777E90',
+    nftCardId: '#ffffff',
     nftCardSubSection: '#202022',
     tableBackgroundColor: '#141416',
     tableTextColor: '#ffffff',


### PR DESCRIPTION
## Why?

Fix deviations from NFT cards on figma

## How?

- [x]  The colors are inverted between the title and text, token id should be white and `cap crowns`
 should be grey
- [x]  We have a top border on the bottom section, there is no full border around the section in the figma doc
- [x]  Another thing with the card, is `cap crowns` should have the same padding as the token id to the left, and `price` and the value on the right

## Tickets?

- [Notion](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=005e5a3ba110469eaa276b2d21f1956f)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1011" alt="Screenshot 2022-05-05 at 10 12 46" src="https://user-images.githubusercontent.com/51888121/166895358-8553df06-c88e-4239-bf97-a502730833ac.png">
