### PR TITLE
fix: 🐛 offers scroll to top on render

### DIFF
--- a/src/components/tables/my-offers-table.tsx
+++ b/src/components/tables/my-offers-table.tsx
@@ -73,6 +73,8 @@ export const MyOffersTable = ({ offersType }: MyOffersTableProps) => {
   const { id: plugPrincipal } = useParams();
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+    
     setTableDetails({
       loading: true,
       loadedOffers: [],


### PR DESCRIPTION
## Why?

When a user has scroll down in the "List view / Landing page" and then while scrolled down at the bottom of the page, clicks the menu to open the "offers", the scroll position is kept thus showing a blank page.

## How?

- Called `window.scroll` to set scroll position on render of offers page

## Tickets?

- [Notion](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=1a3dbf7b54df4028ad57679117053279)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/166961402-9aec7d8c-afd1-4fe3-a445-f23c90f0214b.mov
