### PR TITLE
fix: 🐛 overflow plug dropdown menu issue in small screens

### DIFF
--- a/src/components/core/input-field-set/styles.ts
+++ b/src/components/core/input-field-set/styles.ts
@@ -9,7 +9,8 @@ export const Container = styled('div', {
   variants: {
     name: {
       searchInput: {
-        width: '600px',
+        width: '100%',
+        maxWidth: '600px',
         height: '44px',
       },
       filterInput: {


### PR DESCRIPTION
## Why?

overflow plug dropdown menu issue in small screens

## How?

- [x] update search input styles to fix overflow issue

## Tickets?

- [Notion ticket](https://www.notion.so/In-some-screen-widths-seems-that-by-toggling-the-menu-the-cards-shrink-Also-the-crowns-image-ban-80ed749ebfb84287925c2a6d5a47eb68)


## Demo?

Issue:

https://media.discordapp.net/attachments/911179346604089374/971346260562960454/menu-toggle-issue-shrinks-cards.gif

Fix:


https://user-images.githubusercontent.com/40259256/167062083-0e823d42-ce4b-421e-b0b8-5598a61a3eba.mov


