### PR TITLE
fix: 🐛 view NFT redirect URL

### DIFF
--- a/src/components/modals/buy-now-modal.tsx
+++ b/src/components/modals/buy-now-modal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { ActionButton, Pending, Completed } from '../core';
 import { useAppDispatch, marketplaceActions } from '../../store';
@@ -39,6 +39,7 @@ export const BuyNowModal = ({
   const { t } = useTranslation();
   const { id } = useParams();
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
   const [modalStep, setModalStep] = useState<DirectBuyStatusCodes>(
@@ -95,6 +96,11 @@ export const BuyNowModal = ({
         },
       }),
     );
+  };
+
+  const handleViewNFT = () => {
+    navigate(`/nft/${id}`, { replace: true });
+    setModalOpened(false);
   };
 
   return (
@@ -210,10 +216,7 @@ export const BuyNowModal = ({
             */}
             <ModalButtonsList>
               <ModalButtonWrapper fullWidth>
-                <ActionButton
-                  type="primary"
-                  onChange={handleModalClose}
-                >
+                <ActionButton type="primary" onChange={handleViewNFT}>
                   {t('translation:modals.buttons.viewNFT')}
                 </ActionButton>
               </ModalButtonWrapper>

--- a/src/components/modals/change-price-modal.tsx
+++ b/src/components/modals/change-price-modal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
@@ -47,6 +47,7 @@ export const ChangePriceModal = () => {
   const dispatch = useAppDispatch();
   const { id } = useParams();
   const { loadedNFTS } = useNFTSStore();
+  const navigate = useNavigate();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
   // ChangePrice modal steps: listingInfo/pending/confirmed
@@ -112,6 +113,11 @@ export const ChangePriceModal = () => {
         },
       }),
     );
+  };
+
+  const handleViewNFT = () => {
+    navigate(`/nft/${id}`, { replace: true });
+    setModalOpened(false);
   };
 
   return (
@@ -306,10 +312,7 @@ export const ChangePriceModal = () => {
             */}
             <ModalButtonsList>
               <ModalButtonWrapper fullWidth>
-                <ActionButton
-                  type="primary"
-                  onClick={() => handleModalOpen(false)}
-                >
+                <ActionButton type="primary" onClick={handleViewNFT}>
                   {t('translation:modals.buttons.viewListing')}
                 </ActionButton>
               </ModalButtonWrapper>

--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
@@ -44,6 +44,7 @@ export const MakeOfferModal = ({
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const { id } = useParams();
+  const navigate = useNavigate();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
   const [modalStep, setModalStep] = useState<ListingStatusCodes>(
@@ -86,6 +87,11 @@ export const MakeOfferModal = ({
         },
       }),
     );
+  };
+
+  const handleViewNFT = () => {
+    navigate(`/nft/${tokenId}`, { replace: true });
+    setModalOpened(false);
   };
 
   return (
@@ -256,10 +262,7 @@ export const MakeOfferModal = ({
             */}
             <ModalButtonsList>
               <ModalButtonWrapper fullWidth>
-                <ActionButton
-                  type="primary"
-                  onClick={handleModalClose}
-                >
+                <ActionButton type="primary" onClick={handleViewNFT}>
                   {t('translation:modals.buttons.viewNFT')}
                 </ActionButton>
               </ModalButtonWrapper>

--- a/src/components/modals/sell-modal.tsx
+++ b/src/components/modals/sell-modal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
@@ -55,6 +55,7 @@ export const SellModal = ({
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const { id } = useParams();
+  const navigate = useNavigate();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
   // Sell modal steps: listingInfo/pending/confirmed
@@ -125,6 +126,11 @@ export const SellModal = ({
         },
       }),
     );
+  };
+
+  const handleViewNFT = () => {
+    navigate(`/nft/${tokenId}`, { replace: true });
+    setModalOpened(false);
   };
 
   return (
@@ -323,10 +329,7 @@ export const SellModal = ({
             */}
             <ModalButtonsList>
               <ModalButtonWrapper fullWidth>
-                <ActionButton
-                  type="primary"
-                  onClick={() => handleModalOpen(false)}
-                >
+                <ActionButton type="primary" onClick={handleViewNFT}>
                   {t('translation:modals.buttons.viewListing')}
                 </ActionButton>
               </ModalButtonWrapper>


### PR DESCRIPTION
## Why?

View NFT redirect URL

## How?

- [x] Add redirect url's in `Buy Now`, `Change Price`, `Make Offer` & `Sell Modal`

## Demo?


https://user-images.githubusercontent.com/40259256/167169106-031b0c38-b7af-4a67-954f-7cb0553c56f7.mov


