### PR TITLE
fix: 🐛 error on not enough balance (batch process error handling)

### DIFF
--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -7,6 +7,7 @@ import wicpIdlFactory from '../../../../declarations/wicp.did';
 import marketplaceIdlFactory from '../../../../declarations/marketplace.did';
 import { AppLog } from '../../../../utils/log';
 import { parseAmountToE8S } from '../../../../utils/formatters';
+import { errorMessageHandler } from '../../../../utils/error';
 
 export type MakeOfferProps = DefaultCallbacks & MakeOffer;
 
@@ -45,7 +46,15 @@ export const makeOffer = createAsyncThunk<
         userOwnedTokenId,
         userOfferInPrice,
       ],
-      onSuccess,
+      onSuccess: (res: any) => {
+        if ('Err' in res) throw new Error(
+          errorMessageHandler(res.Err)
+        );
+
+        if (typeof onSuccess !== 'function') return;
+
+        onSuccess()
+      },
       onFail: (res: any) => {
         throw res;
       },

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,13 @@
+// TODO: Create a proper Error message handler
+export const errorMessageHandler = (Err: Record<string, any>) => {
+  const key = Object.keys(Err)[0];
+
+  switch (key) {
+    case 'InsufficientFungibleBalance':
+      return 'Oops! Insufficient fungible balance'
+    default:
+      return 'Oops! Unknown error'
+  }
+}
+
+


### PR DESCRIPTION
## Why?

The UI should throw on error, e.g. user does not have enough balance


## Demo?

<img width="1061" alt="Screenshot 2022-05-06 at 18 38 56" src="https://user-images.githubusercontent.com/236752/167185043-e10bf094-b440-493f-9c40-6cfd7ecba11a.png">

