### PR TITLE
fix: 🐛 plug unlock double popup

### DIFF
--- a/src/components/plug/plug-button.tsx
+++ b/src/components/plug/plug-button.tsx
@@ -3,7 +3,6 @@ import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { useNavigate } from 'react-router-dom';
 import {
   useAppDispatch,
-  usePlugStore,
   useThemeStore,
   plugActions,
 } from '../../store';
@@ -29,6 +28,7 @@ import disconnectDark from '../../assets/buttons/disconnect-dark.svg';
 export type PlugButtonProps = {
   handleClick: () => void;
   text: string;
+  isConnected: boolean,
 };
 
 /* --------------------------------------------------------------------------
@@ -38,10 +38,10 @@ export type PlugButtonProps = {
 export const PlugButton = ({
   handleClick,
   text,
+  isConnected,
 }: PlugButtonProps) => {
   const dispatch = useAppDispatch();
   const { theme } = useThemeStore();
-  const { isConnected } = usePlugStore();
   const [openDropdown, setOpenDropdown] = useState(false);
   const isLightTheme = theme === 'lightTheme';
   const currTheme = theme === 'darkTheme' ? 'dark' : 'light';
@@ -51,6 +51,8 @@ export const PlugButton = ({
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!isConnected) return;
+
     // TODO: check if principal already available in the store
     (async () => {
       const principal = await (
@@ -61,7 +63,7 @@ export const PlugButton = ({
 
       setUserPrincipal(principal.toString());
     })();
-  }, []);
+  }, [isConnected]);
 
   return (
     <Dropdown.Root

--- a/src/components/plug/plug.tsx
+++ b/src/components/plug/plug.tsx
@@ -175,12 +175,14 @@ export const Plug = () => {
         <PlugButton
           handleClick={handleClick}
           text={t('translation:buttons.action.loading')}
+          isConnected={isConnected}
         />
       )}
       {isConnecting && (
         <PlugButton
           handleClick={handleClick}
           text={t('translation:buttons.action.connecting')}
+          isConnected={isConnected}
         />
       )}
       {!isVerifying && !isConnecting && !isConnected && (
@@ -191,6 +193,7 @@ export const Plug = () => {
               ? t('translation:buttons.action.connectToPlug')
               : t('translation:buttons.action.installPlug')
           }
+          isConnected={isConnected}
         />
       )}
       {!isVerifying && !isConnecting && isConnected && (
@@ -200,9 +203,10 @@ export const Plug = () => {
           }}
           text={
             principalId
-              ? formatAddress(principalId)
+              ? formatAddress(principalId as string)
               : t('translation:buttons.action.loading')
           }
+          isConnected={isConnected}
         />
       )}
     </>


### PR DESCRIPTION
## Why?

There shouldn't be two popups for unlocking plug.

## Demo?

![fix-plug-double-popup](https://user-images.githubusercontent.com/236752/167393552-f40f399f-7c2a-4f9e-9f12-2279a8cccc03.gif)

