### PR TITLE
fix: 🐛 view listing button not routing bug

### DIFF
--- a/src/components/modals/buy-now-modal.tsx
+++ b/src/components/modals/buy-now-modal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { ActionButton, Pending, Completed } from '../core';
 import { useAppDispatch, marketplaceActions } from '../../store';
@@ -40,6 +40,7 @@ export const BuyNowModal = ({
   const { id } = useParams();
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
   const [modalStep, setModalStep] = useState<DirectBuyStatusCodes>(
@@ -99,7 +100,8 @@ export const BuyNowModal = ({
   };
 
   const handleViewNFT = () => {
-    navigate(`/nft/${id}`, { replace: true });
+    const tokenId = location.pathname === "/" ? actionTextId : id
+    navigate(`/nft/${tokenId}`, { replace: true });
     setModalOpened(false);
   };
 
@@ -216,7 +218,7 @@ export const BuyNowModal = ({
             */}
             <ModalButtonsList>
               <ModalButtonWrapper fullWidth>
-                <ActionButton type="primary" onChange={handleViewNFT}>
+                <ActionButton type="primary" onClick={handleViewNFT}>
                   {t('translation:modals.buttons.viewNFT')}
                 </ActionButton>
               </ModalButtonWrapper>


### PR DESCRIPTION
## Why?

On nft detail page, after a purchase clicking view NFT does nothing, should refresh the page

## How?

- Passed in id to route page on click of the View NFT button.

## Tickets?

- [Notion](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=110d100bbe3442efb57b922f1db0af8a)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?


https://user-images.githubusercontent.com/51888121/167621270-d8bdecff-5a4a-4fe1-9db7-88e35543d580.mov
