### PR TITLE
fix: 🐛 modified table image loader styles to fix glitching bug

### DIFF
--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -227,7 +227,6 @@ export const TableSkeletonsWrapper = styled('div', {
 export const ImageSkeleton = styled('div', {
   width: '48px',
   height: '48px',
-  margin: '10px 0px',
   borderRadius: '10px',
   marginRight: '12px',
   backgroundColor: 'rgba(0, 0, 0, 0.11)',


### PR DESCRIPTION
## Why?

To fix glitch stemming from added space around image skeleton

## How?

- Removed margin around image skeleton

## Tickets?

- [Notion](https://www.notion.so/Fix-table-loader-glitch-395999b7c9ca49ae891114d473520f99)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/167644475-1a5f2d09-2ca4-4b85-aa08-50154c08e502.mov

