### PR TITLE
style: 💅🏼 table skeletons colour contrast improvement

### DIFF
--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -3,7 +3,7 @@ import { styled, keyframes } from '../../stitches.config';
 
 const fadeInOut = keyframes({
   '0%': {
-    opacity: '0.2',
+    opacity: '0.5',
   },
   '100%': {
     opacity: '1',

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -35,7 +35,7 @@ export const {
       chipsNftBackgroundColor: '#F4F5F6',
       modalOverlay: '#fafbfde6',
       skeletonBackground:
-        'linear-gradient(90deg, rgb(229, 232, 235) 0%, rgb(247, 248, 250) 59.9%)',
+        'linear-gradient(90deg, rgb(209 211 213) 0%, rgb(247, 248, 250) 59.9%)',
       checkboxSelectedFiltersText: '#23262F',
       greyMid: '#767D8E',
       error: '#FD5F51',


### PR DESCRIPTION
## Why?

The activity tab, loading contrast seems to be poor.

## How?

-Modified rgb value of the colour and the opacity.

## Tickets?

- [Notion](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=8dfdeef3f0cc46ff92487b57ddd77be2)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168034886-270ea0a9-76c1-436d-a93c-1275eb38d271.mov
