### PR TITLE
fix: 🐛 show activity tab fieldname "to" and "From/To" flow

### DIFF
--- a/src/store/features/tables/async-thunks/get-cap-activity.ts
+++ b/src/store/features/tables/async-thunks/get-cap-activity.ts
@@ -80,21 +80,23 @@ export const getCAPActivity = createAsyncThunk<
     const result = Items.map((item: any) => {
       pageNo = item.page;
 
+      const isOffering = ['directBuy', 'makeOffer'].includes(item?.event?.operation);
+
       // eslint-disable-next-line no-underscore-dangle
       const parsedFromPrincipal = (() => {
-        if (item?.event?.details?.[2]?.[0] !== 'buyer') {
+        if (!isOffering) {
           // eslint-disable-next-line no-underscore-dangle
-          return getFormattedPrincipal(item?.event?.details?.[3]?.[1]?.Principal?._arr);
+          return getFormattedPrincipal(item?.event?.caller?._arr);
         };
-
-        // eslint-disable-next-line no-underscore-dangle
-        return getFormattedPrincipal(item?.event?.caller?._arr);
-      })();
-      const parsedToPrincipal = (() => {
-        if (item?.event?.details?.[2]?.[0] !== 'buyer') return;
-
+        
         // eslint-disable-next-line no-underscore-dangle
         return getFormattedPrincipal(item?.event?.details?.[3]?.[1]?.Principal?._arr);
+      })();
+      const parsedToPrincipal = (() => {
+        if (!isOffering) return;
+
+        // eslint-disable-next-line no-underscore-dangle
+        return getFormattedPrincipal(item?.event?.details?.[2]?.[1]?.Principal?._arr);
       })();
 
       if (!parsedFromPrincipal) return;


### PR DESCRIPTION
## Why?

The From/To determines the Principal shown based in the details seller/buyer. Although this should probably be terminated in the business logic / service side.

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
