### PR TITLE
feat: 🎸 setup details page social buttons

### DIFF
--- a/src/components/core/accordions/about-accordion.tsx
+++ b/src/components/core/accordions/about-accordion.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
+import copyToClipboard from 'copy-to-clipboard';
 import { useTranslation } from 'react-i18next';
 import * as Accordion from '@radix-ui/react-accordion';
-import { usePlugStore } from '../../../store';
+import { useAppDispatch, usePlugStore } from '../../../store';
 import { LinkButton } from '../buttons';
 import { AccordionContentMetaData } from '../../mock-data/accordion-data';
 import {
@@ -21,6 +22,7 @@ import plugIcon from '../../../assets/plug-circle.svg';
 import { isNFTOwner } from '../../../integrations/kyasshu/utils';
 import { formatAddress } from '../../../utils/formatters';
 import { Icon } from '../../icons';
+import { notificationActions } from '../../../store/features/notifications';
 
 export type AboutAccordionProps = {
   owner?: string;
@@ -28,6 +30,7 @@ export type AboutAccordionProps = {
 
 export const AboutAccordion = ({ owner }: AboutAccordionProps) => {
   const { t } = useTranslation();
+  const dispatch = useAppDispatch();
   const [isAccordionOpen, setIsAccordionOpen] = useState(true);
 
   const { isConnected, principalId: plugPrincipal } = usePlugStore();
@@ -110,19 +113,30 @@ export const AboutAccordion = ({ owner }: AboutAccordionProps) => {
               </Flex>
             ))}
             <ButtonWrapper>
-              <LinkButton type="textBtn">
+              <LinkButton type="textBtn" url="https://crowns.ooo/">
                 {t('translation:buttons.links.website')}
               </LinkButton>
 
-              <LinkButton>
+              <LinkButton url="https://discord.gg/yVEcEzmrgm">
                 <Icon icon="discord" />
               </LinkButton>
 
-              <LinkButton>
+              <LinkButton url="https://twitter.com/cap_ois">
                 <Icon icon="twitter" />
               </LinkButton>
 
-              <LinkButton>
+              <LinkButton
+                handleClick={() => {
+                  copyToClipboard(window.location.href);
+                  dispatch(
+                    notificationActions.setSuccessMessage(
+                      `${t(
+                        'translation:successMessages.copyToClipboard',
+                      )}`,
+                    ),
+                  );
+                }}
+              >
                 <Icon icon="share" />
               </LinkButton>
             </ButtonWrapper>


### PR DESCRIPTION
## Why?

The social buttons in the detail view on the about section are not working.

## How?

- Added functionality to the details page social buttons

## Tickets?

- [Notion](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=2f8271d62dee41f1beeb6705491a1666)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168187220-c65ee393-4ca0-4022-9da9-0338bbc2e053.mov
