### PR TITLE
fix: 🐛 modified border in detail view accordion styles

### DIFF
--- a/src/components/core/accordions/styles.ts
+++ b/src/components/core/accordions/styles.ts
@@ -123,6 +123,7 @@ export const AccordionTrigger = styled(Accordion.Trigger, {
     backgroundColor: {
       open: {
         background: '$openAccordion',
+        borderRadius: '0px',
       },
       notopen: {
         background: '$closeAccordion',


### PR DESCRIPTION
## Why?

Border of accordions on details page do not match that of the designs provided.

## How?

-  Removed bottom radius from about accordion

## Tickets?

- [Notion](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=acd0fb500cd34dd2bc35341fcb991f00)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168188573-0cd6e16e-f514-4feb-820d-f636affe68d5.mov
