### PR TITLE
fix: 🐛  prevent closing modal from outside of the modal content

### DIFF
--- a/src/components/modals/accept-offer-modal.tsx
+++ b/src/components/modals/accept-offer-modal.tsx
@@ -85,7 +85,8 @@ export const AcceptOfferModal = ({
 
     const isAccepted = modalStep === ListingStatusCodes.Accepted;
 
-    if (modalOpenedStatus || !isTokenId(tokenId) || !isAccepted) return;
+    if (modalOpenedStatus || !isTokenId(tokenId) || !isAccepted)
+      return;
 
     // Update NFT owner details in store
     // on successful offer acceptance and closing the modal
@@ -159,7 +160,14 @@ export const AcceptOfferModal = ({
         Modal Content
         ---------------------------------
       */}
-      <ModalContent>
+      <ModalContent
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+      >
         {/*
           ---------------------------------
           Step: 1 -> offerInfo

--- a/src/components/modals/buy-now-modal.tsx
+++ b/src/components/modals/buy-now-modal.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import {
+  useParams,
+  useNavigate,
+  useLocation,
+} from 'react-router-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { ActionButton, Pending, Completed } from '../core';
 import { useAppDispatch, marketplaceActions } from '../../store';
@@ -103,7 +107,7 @@ export const BuyNowModal = ({
     // but instead id preceeds actionTextId
     // so maybe decide which logic is valid and reuse for both cases
     // unless there's a reason why for this
-    const tokenId = location.pathname === "/" ? actionTextId : id
+    const tokenId = location.pathname === '/' ? actionTextId : id;
     navigate(`/nft/${tokenId}`, { replace: true });
     setModalOpened(false);
   };
@@ -142,7 +146,14 @@ export const BuyNowModal = ({
         Modal Content
         ---------------------------------
       */}
-      <ModalContent>
+      <ModalContent
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+      >
         {/*
           ---------------------------------
           Step: 1 -> pending

--- a/src/components/modals/cancel-listing-modal.tsx
+++ b/src/components/modals/cancel-listing-modal.tsx
@@ -102,7 +102,14 @@ export const CancelListingModal = () => {
         Modal Content
         ---------------------------------
       */}
-      <ModalContent>
+      <ModalContent
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+      >
         {/*
           ---------------------------------
           Step: 1 -> cancelList

--- a/src/components/modals/cancel-offer-modal.tsx
+++ b/src/components/modals/cancel-offer-modal.tsx
@@ -99,7 +99,14 @@ export const CancelOfferModal = ({
         Modal Content
         ---------------------------------
       */}
-      <ModalContent>
+      <ModalContent
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+      >
         {/*
           ---------------------------------
           Step: 1 -> cancelOffer

--- a/src/components/modals/change-price-modal.tsx
+++ b/src/components/modals/change-price-modal.tsx
@@ -147,7 +147,14 @@ export const ChangePriceModal = () => {
         Modal Content
         ---------------------------------
       */}
-      <ModalContent>
+      <ModalContent
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+      >
         {/*
           ---------------------------------
           Step: 1 -> listingInfo

--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -139,7 +139,14 @@ export const MakeOfferModal = ({
         Modal Content
         ---------------------------------
       */}
-      <ModalContent>
+      <ModalContent
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+      >
         {/*
           ---------------------------------
           Step: 1 -> listingInfo

--- a/src/components/modals/sell-modal.tsx
+++ b/src/components/modals/sell-modal.tsx
@@ -164,7 +164,14 @@ export const SellModal = ({
         Modal Content
         ---------------------------------
       */}
-      <ModalContent>
+      <ModalContent
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+      >
         {/*
           ---------------------------------
           Step: 1 -> listingInfo


### PR DESCRIPTION
## Why?

Prevent closing modal from outside of the modal content

## How?

- [x] handle `onInteractOutside` event in all modals to prevent default behaviour
- [x]  handle `onEscapeKeyDown` event in all modals to prevent default behaviour

## Tickets?

- [Notion Ticket](https://www.notion.so/Marketplace-Integrations-d29ecd34a9084e7d97bc8b49d5b45be1?p=331cd9189d2d48899b8fb0fa0ed4c255)
