### PR TITLE
style: 💄 modal loader image alignment

### DIFF
--- a/src/components/core/status-indicators/styles.ts
+++ b/src/components/core/status-indicators/styles.ts
@@ -10,7 +10,7 @@ const spin = keyframes({
 });
 
 export const Container = styled('div', {
-  width: '100%',
+  width: 'auto',
   padding: '15px',
   textAlign: 'center',
 });


### PR DESCRIPTION
## Why?

The image is not aligned.

## Demo?

<img width="1088" alt="Screenshot 2022-05-16 at 13 45 33" src="https://user-images.githubusercontent.com/236752/168595431-aeacf743-bc32-4de7-a9ac-d453baa65a55.png">

