### PR TITLE
fix: 🐛 unique id for nft activity table

### DIFF
--- a/src/components/tables/table-layout.tsx
+++ b/src/components/tables/table-layout.tsx
@@ -71,10 +71,11 @@ export const TableLayout = ({
     >
       <table {...getTableProps()}>
         <thead>
-          {headerGroups.map((headerGroup) => (
+          {headerGroups.map((headerGroup, idx) => (
             <tr
               {...headerGroup.getHeaderGroupProps()}
-              key={headerGroup.id}
+              // eslint-disable-next-line react/no-array-index-key
+              key={idx}
             >
               {headerGroup.headers.map((column) => (
                 <th {...column.getHeaderProps()} key={column.id}>


### PR DESCRIPTION
## Why?

Should fix React unique id for key items warning.

