### PR TITLE
refactor: 💡 modify apply price filter button display + clear input field

### DIFF
--- a/src/components/filters/filters.tsx
+++ b/src/components/filters/filters.tsx
@@ -58,6 +58,15 @@ export const Filters = () => {
     dispatch(filterActions.getFilterTraits());
   }, [dispatch]);
 
+  useEffect(() => {
+    if (!displayPriceApplyButton) {
+      setPriceFilterValue({
+        min: '',
+        max: '',
+      });
+    }
+  }, [displayPriceApplyButton]);
+
   const filterExists = (filterName: string) =>
     defaultFilters.some(
       (appliedFilter) => appliedFilter.filterName === filterName,


### PR DESCRIPTION
## Why?

- We should show and hide the apply button for price range filter based on if there is text in the price range boxes
- Price Range filter issue: Input fields are not getting cleared on clearing price filter

## How?

- Refactored function setting the input fields values
- Refactored conditional statement controlling button display
- Added a useEffect to update the price input fields when filter is removed

## Tickets?

- [Notion 1](https://www.notion.so/We-should-show-and-hide-the-apply-button-for-price-range-filter-based-on-if-there-is-text-in-the-pri-fc385e066d184067a3c498c9ff53464e)
- [Notion 2](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=4dcb34a43c89400d89ea262afa70e298)
- [Notion 3](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=b3d263c5d44a41a18212f6cfd92e2414)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168718303-94c0df0b-4cea-4b1c-8a76-329c812d6e12.mov
