### PR TITLE
style: 💅🏼 added in cursor to close icon on filter chips

### DIFF
--- a/src/components/core/chips/styles.ts
+++ b/src/components/core/chips/styles.ts
@@ -129,7 +129,9 @@ export const Traitvalue = styled('div', {
 export const TraitActionContainer = styled('div', {
   display: 'flex',
   padding: '7px',
-  cursor: 'pointer',
+  '&:hover': {
+    cursor: 'pointer',
+  },
 });
 
 export const TraitClear = styled('img', {


### PR DESCRIPTION
## Why?

Cursor is not pointer on hover of close button over My NFT's chip

## How?

- Added cursor property to css styles file

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=d9c8f890c85f4202af63f9722c420368)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168719097-81fc92e2-0dcd-4c79-bbab-d5951f3d0ba5.mov
