### PR TITLE
fix: 🐛 handle multiple calls to getCollectionData API on page load

### DIFF
--- a/src/components/items/collection-items.tsx
+++ b/src/components/items/collection-items.tsx
@@ -38,11 +38,14 @@ export const CollectionItems = () => {
     floorPrice,
   } = useNFTSStore();
 
+  const appliedFiltersCount =
+    appliedFilters?.defaultFilters.length || 0;
+
   useEffect(() => {
-    if (appliedFilters?.defaultFilters.length > 0) return;
+    if (appliedFiltersCount > 0) return;
 
     dispatch(nftsActions.getCollectionData());
-  }, [appliedFilters]);
+  }, [appliedFiltersCount]);
 
   useNFTSFetcher();
 


### PR DESCRIPTION
## Why?

Handle multiple calls to getCollectionData API on page load

## How?

- [x] update useEffect dependency to call `getCollectionData` only when user clears applied filters and on initial load of page

## Tickets?

- [Notion Ticket](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=7a9426144b0b41bc9b637c0ab25c8465)

## Demo?

![Screenshot 2022-05-17 at 11 20 53 AM](https://user-images.githubusercontent.com/40259256/168739089-d01cebf7-ee11-4241-9138-53a3023c61e0.png)

