### PR TITLE
fix: 🐛  show insufficient fungible balance error notification

### DIFF
--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -79,11 +79,14 @@ export const makeOffer = createAsyncThunk<
       id,
       amount,
     };
-  } catch (err) {
+  } catch (err: any) {
     AppLog.error(err);
+
+    const defaultErrorMessage = `Oops! Failed to make offer`;
+
     dispatch(
       notificationActions.setErrorMessage(
-        `Oops! Failed to make offer`,
+        err?.message || defaultErrorMessage,
       ),
     );
     if (typeof onFailure === 'function') {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -4,10 +4,8 @@ export const errorMessageHandler = (Err: Record<string, any>) => {
 
   switch (key) {
     case 'InsufficientFungibleBalance':
-      return 'Oops! Insufficient fungible balance'
+      return 'Oops! Insufficient fungible balance';
     default:
-      return 'Oops! Unknown error'
+      return 'Oops! Unknown error';
   }
-}
-
-
+};


### PR DESCRIPTION
## Why?

Show insufficient fungible balance error notification

## How?

- [x] update catch block in `make-offer` thunk to show `Oops! Insufficient fungible balance` error notification

## Tickets?

- [Notion Ticket](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=b8549c14efdd437e8dff14791c97a8ac)

## Demo?

![Screenshot 2022-05-17 at 1 06 02 PM](https://user-images.githubusercontent.com/40259256/168756693-b70a89c9-49db-4d18-8f2b-3de73bbd1c0c.png)

