### PR TITLE
fix: 🐛  don't auto close the modal after accepting the offer

### DIFF
--- a/src/components/modals/accept-offer-modal.tsx
+++ b/src/components/modals/accept-offer-modal.tsx
@@ -79,6 +79,8 @@ export const AcceptOfferModal = ({
     [loadedNFTS, tokenId],
   );
 
+  // TODO: don't close modal as soon as
+  // accepting the offer
   const handleModalOpen = (modalOpenedStatus: boolean) => {
     setModalOpened(modalOpenedStatus);
     setModalStep(ListingStatusCodes.OfferInfo);


### PR DESCRIPTION
## Why?

Don't auto close the modal after accepting the offer

## How?

- [ ] don't auto close the modal after accepting the offer
- [ ] ++ to be defined

## Tickets?

- [Notion Ticket](https://www.notion.so/Marketplace-Views-1f1e8e171d004ce9abf1288c318d768a?p=9cf8fbd48ec342a083032e6dcf648bac)

## Demo?

++ to be defined
