### PR TITLE
refactor: 💡 reduce font weight on make offer description

### DIFF
--- a/src/components/core/input-field-set/styles.ts
+++ b/src/components/core/input-field-set/styles.ts
@@ -61,7 +61,7 @@ export const Input = styled('input', {
       modalInput: {
         padding: '15px 116px 15px 21px',
         fontSize: '22px',
-        fontWeight: 600,
+        fontWeight: 500,
         lineHeight: '27px',
       },
     },

--- a/src/components/modals/styles.ts
+++ b/src/components/modals/styles.ts
@@ -115,7 +115,7 @@ export const ModalTitle = styled(DialogPrimitive.Title, {
 
 export const ModalDescription = styled(DialogPrimitive.Description, {
   fontSize: '18px',
-  fontWeight: '600',
+  fontWeight: '500',
   lineHeight: '20px',
   color: '#767D8E',
   margin: '0px',


### PR DESCRIPTION
## Why?

Reduce font weight to be consistent with design requirements

## How?

- Reduced font weight on description + placeholder

## Tickets?

- [Notion](https://www.notion.so/5-16-Jelly-Review-a600cfdd155e4a068d01f38a69639299#00e15a80c35141f880b0f635ae41a299)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-05-18 at 01 15 22" src="https://user-images.githubusercontent.com/51888121/168935400-af9f3842-6901-4780-91c6-066ae5a08129.png">
