### PR TITLE
refactor: 💡 route from nft details page to activity table

### DIFF
--- a/src/components/nft-action-bar/nft-action-bar.tsx
+++ b/src/components/nft-action-bar/nft-action-bar.tsx
@@ -12,6 +12,7 @@ import {
   ActionText,
   ButtonListWrapper,
   ButtonWrapper,
+  RouteLink,
 } from './styles';
 
 import { usePlugStore } from '../../store';
@@ -68,12 +69,12 @@ export const NftActionBar = ({
   return (
     <Container>
       <NftActionBarWrapper>
-        <div onClick={() => history.back()}>
+        <RouteLink onClick={() => history.back()}>
           <ActionText>
             <Icon icon="arrow-left-circle" paddingRight />
-            {t('translation:buttons.action.backToResults')}
+            {t('translation:buttons.links.back')}
           </ActionText>
-        </div>
+        </ RouteLink>
         {showNFTActionButtons &&
           (isConnectedOwner ? (
             <OnConnected isListed={isListed} />

--- a/src/components/nft-action-bar/styles.ts
+++ b/src/components/nft-action-bar/styles.ts
@@ -25,6 +25,7 @@ export const ActionText = styled('p', {
   color: '#777E90',
   display: 'flex',
   margin: '0',
+  textTransform: 'capitalize',
 
   '& img': {
     marginRight: '5px',
@@ -39,3 +40,7 @@ export const ButtonListWrapper = styled('div', {
 export const ButtonWrapper = styled('div', {
   marginLeft: '10px',
 });
+
+export const RouteLink = styled('div', {
+  cursor: 'pointer',
+})


### PR DESCRIPTION
## Why?

To allow user route back to activity tab if they are coming from there.

## How?

- Route to previous page using `history.back()` method

## Tickets?

- [Notion](https://www.notion.so/5-16-Jelly-Review-a600cfdd155e4a068d01f38a69639299#425e27bf4150441582ee127138a1dfa6)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168933269-8057c100-3fc3-4ee9-aa50-1e5461122860.mov
