### PR TITLE
refactor: 💡 outline make offer secondary button

### DIFF
--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -131,7 +131,7 @@ const OnConnected = ({
           )}
           {!loadingOffers && !userMadeOffer && (
             <ButtonDetailsWrapper>
-              <MakeOfferModal secondaryBtn={isListed} />
+              <MakeOfferModal isNFTListed={isListed} />
             </ButtonDetailsWrapper>
           )}
           {!loadingOffers && userMadeOffer && (

--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -37,7 +37,7 @@ export type MakeOfferModalProps = {
   nftTokenId?: string;
   isOfferEditing?: boolean;
   offerPrice?: bigint;
-  secondaryBtn?: boolean;
+  isNFTListed?: boolean;
 };
 
 export const MakeOfferModal = ({
@@ -46,7 +46,7 @@ export const MakeOfferModal = ({
   nftTokenId,
   isOfferEditing,
   offerPrice,
-  secondaryBtn,
+  isNFTListed,
 }: MakeOfferModalProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -122,7 +122,7 @@ export const MakeOfferModal = ({
           <ActionText>{actionText}</ActionText>
         ) : (
           <MakeOfferModalTrigger>
-            <ActionButton type={secondaryBtn ? 'outline' : 'primary'}>
+            <ActionButton type={isNFTListed ? 'outline' : 'primary'}>
               {isOfferEditing
                 ? t('translation:buttons.action.editOffer')
                 : t('translation:buttons.action.makeOffer')}


### PR DESCRIPTION
## Why?

Make offer button should be outlined when it appears as a secondary button on details view

## How?

- Add outline to make offer button when it is secondary

## Tickets?

- [Notion](https://www.notion.so/5-16-Jelly-Review-a600cfdd155e4a068d01f38a69639299#cc40c7f96aab4341adfac7507a44cd79)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-05-18 at 01 07 48" src="https://user-images.githubusercontent.com/51888121/168934021-735e62d6-f565-4c94-873a-2b23c215aa0a.png">

