### PR TITLE
refactor: 💡 set default min value for price filter

### DIFF
--- a/src/components/filters/filters.tsx
+++ b/src/components/filters/filters.tsx
@@ -154,7 +154,6 @@ export const Filters = () => {
 
       return;
     }
-    // eslint-disable-next-line no-lonely-if
     if (priceFilterValue.min !== '' && priceFilterValue.max !== '') {
       applyFilter(
         `${t('translation:filters.priceRange')}`,


### PR DESCRIPTION
## Why?

When someone types in just the max number in price filter we should just auto assume the min value is 0 instead of giving them an error

## How?

- Added a conditional to fulfil this purpose

## Tickets?

- [Notion](https://www.notion.so/5-16-Jelly-Review-a600cfdd155e4a068d01f38a69639299#07aaddd3705b410d8d243eb8d77de874)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168934129-461c2b3b-12ea-4607-8807-c915ba2f2296.mov
