### PR TITLE
refactor: 💡 modified action text hover style

### DIFF
--- a/src/components/modals/styles.ts
+++ b/src/components/modals/styles.ts
@@ -323,7 +323,7 @@ export const ActionText = styled('span', {
   cursor: 'pointer',
 
   '&:hover': {
-    textDecoration: 'underline',
+    opacity: '60%',
   },
 });
 


### PR DESCRIPTION
## Why?

Change the css design on hover of action text on the nft cards

## How?

- Remove underline on hover
- Add opacity on hover

## Tickets?

- [Notion](https://www.notion.so/5-16-Jelly-Review-a600cfdd155e4a068d01f38a69639299#ae640ed7c8254160af63cc91e361cc93)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168934312-652afe5c-412a-4366-aeb4-8a2859b92e49.mov
