### PR TITLE
refactor: 💡 swap direction of arrow icons on offer about accordions

### DIFF
--- a/src/components/core/accordions/about-accordion.tsx
+++ b/src/components/core/accordions/about-accordion.tsx
@@ -120,7 +120,7 @@ export const AboutAccordion = ({ owner }: AboutAccordionProps) => {
               )}`}
             </p>
           </div>
-          <Icon icon="chevron-down" rotate={isAccordionOpen} />
+          <Icon icon="chevron-up" rotate={isAccordionOpen} />
         </AccordionTrigger>
         <AccordionContent
           padding="medium"

--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -254,7 +254,7 @@ export const OfferAccordion = ({
                 {`${t('translation:accordions.offer.header.offer')}`}
               </p>
             </div>
-            <Icon icon="chevron-down" rotate={isAccordionOpen} />
+            <Icon icon="chevron-up" rotate={isAccordionOpen} />
           </AccordionTrigger>
           <AccordionContent
             padding="none"

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -10,6 +10,7 @@ import { FaArrowCircleLeft } from '@react-icons/all-files/fa/FaArrowCircleLeft';
 import { FaSignOutAlt } from '@react-icons/all-files/fa/FaSignOutAlt';
 import { FaTag } from '@react-icons/all-files/fa/FaTag';
 import { FaChevronDown } from '@react-icons/all-files/fa/FaChevronDown';
+import { FaChevronUp } from '@react-icons/all-files/fa/FaChevronUp';
 import { FaEllipsisH } from '@react-icons/all-files/fa/FaEllipsisH';
 import { FaRegClone } from '@react-icons/all-files/fa/FaRegClone';
 import { FaCheck } from '@react-icons/all-files/fa/FaCheck';
@@ -40,6 +41,7 @@ export const Icons = {
   disconnect: FaSignOutAlt,
   offer: FaTag,
   'chevron-down': FaChevronDown,
+  'chevron-up': FaChevronUp,
   ellipsis: FaEllipsisH,
   copy: FaRegClone,
   check: FaCheck,


### PR DESCRIPTION
## Why?

Accordion arrows icons were being used the wrong way

## How?

- Changed icon being used on accordions

## Tickets?

- [Notion](https://www.notion.so/5-16-Jelly-Review-a600cfdd155e4a068d01f38a69639299#bdbf0a21906b470eaa003a73bbcb9eaf)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/168934486-c1df065a-dc7a-49ae-b4f6-f9653c0b298d.mov
