### PR TITLE
fix: 🐛infinite confirmation before plug request

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -37,7 +37,7 @@ export const formatPriceValue = (price: string) => {
 export const parseAmountToE8S = (amount: string) => {
   if (!amount) return BigInt(0);
 
-  const computedAmount = Number(amount) * E8S_PER_ICP;
+  const computedAmount = Math.round(Number(amount) * E8S_PER_ICP);
 
   return BigInt(computedAmount);
 };
@@ -50,7 +50,8 @@ export const parseE8SAmountToWICP = (amount: bigint) => {
   return computedWICP.toString();
 };
 
-export const parseAmountToE8SAsNum = (amount: string) => Number(parseAmountToE8S(amount));
+export const parseAmountToE8SAsNum = (amount: string) =>
+  Number(parseAmountToE8S(amount));
 
 const fixStringEnding = (str: string): string =>
   str.replace(/0+$/, '').replace(/\.$/, '');


### PR DESCRIPTION
Round computed amount for parseAmountToE8S

## Why?

Floating precision point error on js:
![image](https://user-images.githubusercontent.com/30053103/169159607-2943953d-2aba-4c3d-b326-a83d7edf7ac8.png)

## Tickets

- [Ticket 1](https://www.notion.so/We-are-getting-an-infinite-confirmation-and-no-plug-popup-with-certain-values-63f0eb04469d41e8a96a998bc08f10c4)