### PR TITLE
refactor: 💡 retaining sorting filter state

### DIFF
--- a/src/components/core/dropdown/price-filter-dropdown.tsx
+++ b/src/components/core/dropdown/price-filter-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   filterActions,
@@ -70,9 +70,10 @@ export const SortByFilterDropdown = React.memo(() => {
     dispatch(filterActions.setSortingFilter(key));
   };
 
-  const sortValue = sortOptions.find(
-    (sortItem) => sortItem.key === sortBy,
-  )?.value;
+  const sortValue = useMemo(() => {
+    return sortOptions.find((sortItem) => sortItem.key === sortBy)
+      ?.value;
+  }, [sortOptions, sortBy]);
 
   return (
     <DropdownRoot


### PR DESCRIPTION
## Why?

Sorting state is not retaining

## How?

- Worked with redux state of sort filters to find the value and to display it

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=00c8932452ea432b8003a9d5759bb573)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/169171961-a9b5bbde-1ac5-47fb-8c03-cdc1bd905800.mov
