### PR TITLE
refactor: 💡 sticky filters header

### DIFF
--- a/src/components/filters/filters.tsx
+++ b/src/components/filters/filters.tsx
@@ -29,6 +29,7 @@ import {
   CheckboxFilters,
   FilterButtonWrapper,
   CollapseIcon,
+  FilterHeader,
 } from './styles';
 import CheckboxAccordionSkeleton from '../core/accordions/checkbox-accordion-skeleton';
 
@@ -177,29 +178,29 @@ export const Filters = () => {
       </CloseFilterContainer>
       {collapsed && (
         <FiltersContainer>
+          <FilterHeader>
+            <Heading>Filters</Heading>
+            {defaultFilters.length ? (
+              <ClearButton
+                onClick={() => {
+                  dispatch(filterActions.clearAllFilters());
+                  dispatch(
+                    settingsActions.setPriceApplyButton(false),
+                  );
+                  dispatch(filterActions.setMyNfts(false));
+                  setPriceFilterValue({
+                    min: '',
+                    max: '',
+                  });
+                }}
+              >
+                {`${t('translation:filters.clearAll')}`}
+              </ClearButton>
+            ) : (
+              ''
+            )}
+          </FilterHeader>
           <FiltersWrapper>
-            <Flex>
-              <Heading>Filters</Heading>
-              {defaultFilters.length ? (
-                <ClearButton
-                  onClick={() => {
-                    dispatch(filterActions.clearAllFilters());
-                    dispatch(
-                      settingsActions.setPriceApplyButton(false),
-                    );
-                    dispatch(filterActions.setMyNfts(false));
-                    setPriceFilterValue({
-                      min: '',
-                      max: '',
-                    });
-                  }}
-                >
-                  {`${t('translation:filters.clearAll')}`}
-                </ClearButton>
-              ) : (
-                ''
-              )}
-            </Flex>
             <FilterSection>
               <FilterGroup>
                 <Subheadings>Display</Subheadings>

--- a/src/components/filters/styles.ts
+++ b/src/components/filters/styles.ts
@@ -42,7 +42,7 @@ export const FiltersContainer = styled('div', {
 });
 
 export const FiltersWrapper = styled('div', {
-  padding: '32px 20px',
+  padding: '0 20px 32px',
 });
 
 export const Flex = styled('div', {
@@ -64,6 +64,10 @@ export const FilterSection = styled('div', {
   display: 'flex',
   flexDirection: 'column',
   margin: '35px 0px 0px',
+
+  '&:nth-child(1)': {
+    marginBottom: '15px',
+  },
 });
 
 export const FilterGroup = styled('div', {
@@ -160,4 +164,16 @@ export const CollapseIcon = styled(Icon, {
   color: '$mainTextColor',
   width: '24px',
   height: '24px',
+});
+
+export const FilterHeader = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  margin: '0',
+  position: 'sticky',
+  width: '100%',
+  background: '$backgroundColor',
+  top: '0',
+  padding: '32px 20px 20px',
+  zIndex: '5',
 });


### PR DESCRIPTION
## Why?

When scrolling up, the headers “Filter” should stay constant on the left pane

## How?

- Adding sticky styling to filter heading text

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=0574fcabe5ce4882a522f4147281c7ab)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/169172294-4f607f0d-f273-4742-a6e4-6d8eb7db9fec.mov
