### PR TITLE
fix: 🐛 typo in metadata title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1"
     />
     <meta name="theme-color" content="#000000" />
-    <title>JellyJelly - Marketplace dApp ✨</title>
+    <title>Jelly - Marketplace dApp ✨</title>
     <meta name="description" content="">
     <link rel="icon" href="https://storageapi.fleek.co/fleek-team-bucket/jelly/favicon.ico">
     <!-- Open Graph / Facebook -->


### PR DESCRIPTION
## Why?

Metadata title had a typo

## How?

- Deleted additional Jelly text

## Tickets?

- [Ticket 1](the-ticket-url-here)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="129" alt="Screenshot 2022-05-19 at 10 37 18" src="https://user-images.githubusercontent.com/51888121/169263011-a6e6e90f-8017-48ef-ae0f-58f1ab6d63a3.png">
