### PR TITLE
style: 💅🏼 changed background colour of notifications bar

### DIFF
--- a/src/components/toast/styles.ts
+++ b/src/components/toast/styles.ts
@@ -48,7 +48,7 @@ export const ToastViewport = styled(ToastPrimitive.Viewport, {
 });
 
 export const Toast = styled(ToastPrimitive.Root, {
-  backgroundColor: 'white',
+  backgroundColor: '$toastBackground',
   borderRadius: '20px',
   boxShadow:
     'hsl(206 22% 7% / 35%) 0px 10px 38px -10px, hsl(206 22% 7% / 20%) 0px 10px 20px -15px',

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -42,6 +42,7 @@ export const {
       primary: '#5542CF',
       success: '#00AC7C',
       modalText: '#767D8E',
+      toastBackground: '#ffffff',
     },
     space: {},
     fonts: {},
@@ -90,6 +91,7 @@ export const darkTheme = createTheme({
     primary: '#5542CF',
     success: '#00AC7C',
     modalText: '#767D8E',
+    toastBackground: '#1e1e1e',
   },
   shadows: {
     default: 'none',


### PR DESCRIPTION
## Why?

Bg colour of notification cards on dark mode should be #1E1E1E as per figma

## How?

- Added new colour to stitches.config file
- Replaced background colour with new colour

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=ea40f333c7f942309a8121f56daba525)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="444" alt="Screenshot 2022-05-19 at 11 04 53" src="https://user-images.githubusercontent.com/51888121/169268851-1d5c27d9-2d01-4ca4-8e8e-445e6accb94f.png">

<img width="444" alt="Screenshot 2022-05-19 at 11 09 13" src="https://user-images.githubusercontent.com/51888121/169269324-16f7cc96-7a3b-4ce9-b839-9497e9aee40d.png">