### PR TITLE
fix: 🐛 NFT card hover issue

### DIFF
--- a/src/components/core/cards/nft-card/nft-card.tsx
+++ b/src/components/core/cards/nft-card/nft-card.tsx
@@ -73,14 +73,12 @@ const OnConnected = ({
       {showSellOptions && (
         <div role="dialog">
           <SellModal
-            onClose={() => {}}
             actionText={`${t('translation:nftCard.sell')}`}
             nftTokenId={tokenId}
             isTriggerVisible={!isForSale}
           />
 
           <ChangePriceModal
-            onClose={() => {}}
             actionText={`${t('translation:nftCard.changePrice')}`}
             nftTokenId={tokenId}
             nftPrice={price}
@@ -91,7 +89,6 @@ const OnConnected = ({
       {(showBuyerOptions && (
         <div role="dialog">
           <BuyNowModal
-            onClose={() => {}}
             actionText={`${t('translation:nftCard.forSale')}`}
             actionTextId={Number(tokenId)}
             price={
@@ -100,7 +97,6 @@ const OnConnected = ({
             isTriggerVisible={isForSale}
           />
           <MakeOfferModal
-            onClose={() => {}}
             actionText={`${t('translation:nftCard.forOffer')}`}
             nftTokenId={tokenId}
             isTriggerVisible={!isForSale}


### PR DESCRIPTION
## Why?

NFT card hover issue

## How?

- [x] Add default value to `isPreview` key
- [x] Remove unnecessary states to control modal like `setModalStatus` and `Close`

## Tickets?

- [Ticket](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=c07eca063f3449e5a0c620d21ebb5b8f)

## Demo?


https://user-images.githubusercontent.com/40259256/169473670-3c06d4e0-30f1-4b30-a69d-f2fcc1a3aed8.mov


