### PR TITLE
fix: 🐛 make offer input validation

### DIFF
--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -205,7 +205,7 @@ export const MakeOfferModal = ({
                 <ActionButton
                   type="primary"
                   onClick={handleSubmitOffer}
-                  disabled={!amount}
+                  disabled={!amount || Number(amount) <= 0}
                 >
                   {t('translation:modals.buttons.submitOffer')}
                 </ActionButton>


### PR DESCRIPTION
## Why?

No null value validation in Enter Amount input

## How?

- Added a check for null/negative values

## Tickets?

- [Notion](https://www.notion.so/No-null-value-validation-in-Enter-Amount-input-36ad11bb1459468aaa7232f49cf3046c)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/169501074-bed40173-4416-4657-9217-e8ca277b244e.mov
