### PR TITLE
fix: 🐛 changed text link color to primary

### DIFF
--- a/src/components/core/table-cells/styles.ts
+++ b/src/components/core/table-cells/styles.ts
@@ -201,7 +201,7 @@ export const TextLinkDetails = styled('a', {
         fontSize: '16px',
         fontWeight: '500',
         lineHeight: '19px',
-        color: '$tableLinkTextColor',
+        color: '$primary',
       },
     },
   },


### PR DESCRIPTION
## Why?

“You" is incorrect color here

## How?

- Changed text link color to new primary color

## Tickets?

- [Notion](https://www.notion.so/You-is-incorrect-color-here-ref-to-designs-screenshot-1cc6cfac9a14453785e160be0bc3295d)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-05-20 at 22 08 08" src="https://user-images.githubusercontent.com/51888121/169719319-653e596e-393d-41c0-86da-dfe5deb98827.png">
