### PR TITLE
fix: 🐛 offers height running too long

### DIFF
--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -9,7 +9,6 @@ export const Container = styled('div', {
 export const TableWrapper = styled('div', {
   // marginTop: '44px', // TODO: make variant
   width: '100%',
-  minHeight: '20vh',
 
   table: {
     borderSpacing: '0',


### PR DESCRIPTION
## Why?

Table height (under offers of a particular NFT page) seems longer

## How?

- Remove set height

## Tickets?

- [Notion](https://www.notion.so/Table-height-under-offers-of-a-particular-NFT-page-seems-longer-06f9ae96163b48c193501896c0e6afe6)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-05-20 at 22 08 08" src="https://user-images.githubusercontent.com/51888121/169719387-1975eac5-b139-4814-ba91-4f006a788882.png">
