### PR TITLE
fix: 🐛 pending status description in all modals

### DIFF
--- a/src/components/modals/accept-offer-modal.tsx
+++ b/src/components/modals/accept-offer-modal.tsx
@@ -313,6 +313,11 @@ export const AcceptOfferModal = ({
                 <ModalTitle>
                   {t('translation:modals.title.pendingConfirmation')}
                 </ModalTitle>
+                <ModalDescription>
+                  {t(
+                    'translation:modals.description.pendingConfirmation',
+                  )}
+                </ModalDescription>
               </ModalHeader>
               {/*
               ---------------------------------

--- a/src/components/modals/cancel-listing-modal.tsx
+++ b/src/components/modals/cancel-listing-modal.tsx
@@ -173,6 +173,11 @@ export const CancelListingModal = () => {
                 <ModalTitle>
                   {t('translation:modals.title.pendingConfirmation')}
                 </ModalTitle>
+                <ModalDescription>
+                  {t(
+                    'translation:modals.description.pendingConfirmation',
+                  )}
+                </ModalDescription>
               </ModalHeader>
               {/*
             ---------------------------------

--- a/src/components/modals/cancel-offer-modal.tsx
+++ b/src/components/modals/cancel-offer-modal.tsx
@@ -170,6 +170,11 @@ export const CancelOfferModal = ({
                 <ModalTitle>
                   {t('translation:modals.title.pendingConfirmation')}
                 </ModalTitle>
+                <ModalDescription>
+                  {t(
+                    'translation:modals.description.pendingConfirmation',
+                  )}
+                </ModalDescription>
               </ModalHeader>
               {/*
             ---------------------------------

--- a/src/components/modals/change-price-modal.tsx
+++ b/src/components/modals/change-price-modal.tsx
@@ -301,6 +301,11 @@ export const ChangePriceModal = ({
                 <ModalTitle>
                   {t('translation:modals.title.pendingConfirmation')}
                 </ModalTitle>
+                <ModalDescription>
+                  {t(
+                    'translation:modals.description.pendingConfirmation',
+                  )}
+                </ModalDescription>
               </ModalHeader>
               {/*
               ---------------------------------

--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -236,6 +236,11 @@ export const MakeOfferModal = ({
                 <ModalTitle>
                   {t('translation:modals.title.pendingConfirmation')}
                 </ModalTitle>
+                <ModalDescription>
+                  {t(
+                    'translation:modals.description.pendingConfirmation',
+                  )}
+                </ModalDescription>
               </ModalHeader>
               {/*
               ---------------------------------

--- a/src/components/modals/sell-modal.tsx
+++ b/src/components/modals/sell-modal.tsx
@@ -323,6 +323,11 @@ export const SellModal = ({
                 <ModalTitle>
                   {t('translation:modals.title.pendingConfirmation')}
                 </ModalTitle>
+                <ModalDescription>
+                  {t(
+                    'translation:modals.description.pendingConfirmation',
+                  )}
+                </ModalDescription>
               </ModalHeader>
               {/*
               ---------------------------------


### PR DESCRIPTION
## Why?

Add pending status description in all modals

## How?

- [x] add pending status description in all modals when state is pending and awaiting for plug approval

## Demo?

![Screenshot 2022-05-23 at 3 53 56 PM](https://user-images.githubusercontent.com/40259256/169799925-5e6c393f-af55-4664-939b-fd2cf393fda0.png)

