### PR TITLE
fix: 🐛 fixed nft activity table header text color

### DIFF
--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -123,8 +123,7 @@ export const TableWrapper = styled('div', {
           thead: {
             tr: {
               th: {
-                // color: '#767D8E',
-                color: '$mainTextColor',
+                color: '$greyMid',
                 fontSize: '18px',
                 fontWeight: '500',
                 lineHeight: '22px',


### PR DESCRIPTION
## Why?

Table header displaying the wrong colour

## How?

- Changed table header colour to tailor the figma design

## Tickets?

- [Notion](https://www.notion.so/Desktop-8f9ce9e78b8b417a9260b16ec5958466#07b32e702a9a492da8664ea2a4843ad8e)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-05-23 at 21 49 37" src="https://user-images.githubusercontent.com/51888121/169904248-309379e0-ad1c-4426-83f2-1bec0bbfa8d5.png">