### PR TITLE
fix: 🐛 fixed padding + font weight inaccuracy on trait chips

### DIFF
--- a/src/components/core/chips/styles.ts
+++ b/src/components/core/chips/styles.ts
@@ -71,7 +71,7 @@ export const TraitSpecsContainer = styled('div', {
 
 export const TraitName = styled('div', {
   fontSize: '16px',
-  fontWeight: '600',
+  fontWeight: '500',
   lineHeight: '19px',
   marginBottom: '2px',
 
@@ -128,7 +128,6 @@ export const Traitvalue = styled('div', {
 
 export const TraitActionContainer = styled('div', {
   display: 'flex',
-  padding: '7px',
   '&:hover': {
     cursor: 'pointer',
   },


### PR DESCRIPTION
## Why?

Font weight and padding styling were inaccurate

## How?

- Reduced padding on the icon
- Reduced text font weight

## Tickets?

- [Notion 1](https://www.notion.so/Desktop-8f9ce9e78b8b417a9260b16ec5958466#0ac0926f88354918801f9988b1651e8a)
- [Notion 2](https://www.notion.so/Desktop-8f9ce9e78b8b417a9260b16ec5958466#07b32e702a9a492da8664ea2a4843ad8)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="525" alt="Screenshot 2022-05-23 at 21 37 02" src="https://user-images.githubusercontent.com/51888121/169902355-2fa915d5-6d92-4eb9-9a57-2ecedac966ac.png">
