### PR TITLE
fix: 🐛 styling issues on checkbox accordion

### DIFF
--- a/src/components/core/accordions/styles.ts
+++ b/src/components/core/accordions/styles.ts
@@ -244,14 +244,14 @@ export const AccordionTrigger = styled(Accordion.Trigger, {
     alignItems: 'center',
 
     '& span': {
-      margin: '0 0 0 10px',
+      margin: '0 0 0 5px',
       fontStyle: 'normal',
-      fontWeight: '800',
+      fontWeight: '500',
       fontSize: '16px',
       lineHeight: '19px',
       display: 'flex',
       alignItems: 'center',
-      color: '$checkboxSelectedFiltersText',
+      color: '$primary',
     },
   },
 

--- a/src/components/core/checkbox/checkbox.tsx
+++ b/src/components/core/checkbox/checkbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { roundOffDecimalValue } from '../../../utils/nfts';
 import { Wrapper } from './styles';
 
 export type CheckboxProps = {
@@ -33,6 +34,6 @@ export const Checkbox = ({
       <span />
       {value}
     </label>
-    <span>{`${occurence} (${percentage}%)`}</span>
+    <span>{`${occurence} (${roundOffDecimalValue(Number(percentage), 1)}%)`}</span>
   </Wrapper>
 );


### PR DESCRIPTION
## Why?

Styles were missing from the checkbox accordion

## How?

- Fixed missing styles on the checkbox accordion

## Tickets?

- [Notion](https://www.notion.so/Desktop-8f9ce9e78b8b417a9260b16ec5958466#f94454a607ed4bbba2f6cd74a01b21e3)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="382" alt="Screenshot 2022-05-23 at 21 21 55" src="https://user-images.githubusercontent.com/51888121/169899739-b91148c2-cd2f-436f-b29d-38df546ddf6f.png">
