### PR TITLE
fix: 🐛 handle insufficient balance in direct buy

### DIFF
--- a/src/store/features/marketplace/async-thunks/direct-buy.ts
+++ b/src/store/features/marketplace/async-thunks/direct-buy.ts
@@ -73,11 +73,14 @@ export const directBuy = createAsyncThunk<
       tokenId,
       price,
     };
-  } catch (err) {
+  } catch (err: any) {
     AppLog.error(err);
+
+    const defaultErrorMessage = `Oops! Failed to direct buy`;
+
     dispatch(
       notificationActions.setErrorMessage(
-        'Oops! Failed to direct buy',
+        err?.message || defaultErrorMessage,
       ),
     );
     if (typeof onFailure === 'function') {


### PR DESCRIPTION
## Why?

Handle insufficient balance in direct buy

## How?

- [x] update error handling in `direct buy` to catch insufficient balance
