### PR TITLE
fix: 🐛 modified background colour on accordions

### DIFF
--- a/src/components/core/accordions/styles.ts
+++ b/src/components/core/accordions/styles.ts
@@ -265,7 +265,7 @@ export const AccordionContent = styled(Accordion.Content, {
   variants: {
     backgroundColor: {
       open: {
-        background: '$backgroundColor',
+        background: '$openAccordion',
       },
       notopen: {
         backgroundColor: 'white',
@@ -303,7 +303,8 @@ export const Description = styled('p', {
   fontSize: '16px',
   lineHeight: '19px',
   color: '#777E90',
-  margin: '15px 0 25px',
+  margin: '0',
+  padding: '15px 0 25px',
 });
 
 export const Flex = styled('div', {

--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -237,7 +237,7 @@ export const EmptyStateMessage = styled('td', {
         fontSize: '16px',
         lineHeight: '19px',
         color: '$mainTextColor',
-        margin: '50px 25px',
+        padding: '50px 25px',
       },
       mediumTable: {
         fontWeight: '500',


### PR DESCRIPTION
## Why?

Wrong background colour was being used for the accordions

## How?

- Changed background colour
- Replaced margin with padding

## Tickets?

- [Notion](https://www.notion.so/Desktop-8f9ce9e78b8b417a9260b16ec5958466#fd4e96360fc64528a7f91bbe79da1443)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/170165603-7c0d4a40-fa85-4bce-9aaf-50e05b3fbb9d.mov
