### PR TITLE
fix: 🐛 fixed styling issues on copy link dropdown

### DIFF
--- a/src/components/core/dropdown/card-options-dropdown.tsx
+++ b/src/components/core/dropdown/card-options-dropdown.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownGroup,
   DropdownButtonContainer,
+  EllipsisIcon,
 } from './styles';
 import { NFTMetadata } from '../../../declarations/legacy';
 import { Icon } from '../../icons';
@@ -45,7 +46,7 @@ export const CardOptionsDropdown = ({
         onClick={(e) => e.preventDefault()}
       >
         <DropdownButtonContainer>
-          <Icon icon="ellipsis" />
+          <EllipsisIcon icon="ellipsis" />
         </DropdownButtonContainer>
       </DropdownMenu.Trigger>
 

--- a/src/components/core/dropdown/styles.ts
+++ b/src/components/core/dropdown/styles.ts
@@ -1,5 +1,6 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { styled } from '../../../stitches.config';
+import { Icon } from '../../icons';
 
 export const DropdownRoot = styled(DropdownMenu.Root, {
   background: '$backgroundColor',
@@ -58,8 +59,11 @@ export const DropdownContent = styled(DropdownMenu.Content, {
   variants: {
     width: {
       small: {
-        marginTop: '2px',
-        minWidth: '160px',
+        marginTop: '0',
+        minWidth: '140px',
+        left: '-20px',
+        top: '-8px',
+        position: 'absolute',
       },
     },
   },
@@ -114,3 +118,7 @@ export const DropdownRadioMenuItem = styled(
 );
 
 export const DropdownMenuItem = styled(DropdownMenu.Item, {});
+
+export const EllipsisIcon = styled(Icon, {
+  color: '$iconGrey',
+});

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -43,6 +43,7 @@ export const {
       success: '#00AC7C',
       modalText: '#767D8E',
       toastBackground: '#ffffff',
+      iconGrey: '#767D8F'
     },
     space: {},
     fonts: {},


### PR DESCRIPTION
## Why?

Alignment and size issues with copy link dropdown

## How?

- Modified top and left spacing
- Reduced dropdown width

## Tickets?

- [Notion](https://www.notion.so/Desktop-8f9ce9e78b8b417a9260b16ec5958466#9e9517e9a0cd4b12b99c2d62e3c458f9)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="775" alt="Screenshot 2022-05-24 at 17 45 46" src="https://user-images.githubusercontent.com/51888121/170165423-b04988ba-c453-4947-9fda-564450d7af46.png">
