### PR TITLE
fix: 🐛 removed extra spacing on plug button

### DIFF
--- a/src/components/plug/styles.ts
+++ b/src/components/plug/styles.ts
@@ -13,7 +13,6 @@ export const PlugButtonContainer = styled('button', {
   lineHeight: '19px',
   borderRadius: '15px',
   border: 'none',
-  marginLeft: '10px',
   background:
     'linear-gradient(93.07deg, #FFD719 0.61%, #F754D4 33.98%, #1FD1EC 65.84%, #48FA6B 97.7%)',
 


### PR DESCRIPTION
## Why?

Spacing issues with plug and theme toggle button

## How?

- Reduced spacing between plug and theme toggle button

## Tickets?

- [Notion](https://www.notion.so/Desktop-8f9ce9e78b8b417a9260b16ec5958466#6f2231871f3344f4842cdc1aa0053302)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="244" alt="Screenshot 2022-05-25 at 11 14 38" src="https://user-images.githubusercontent.com/51888121/170239349-d75c82dd-a995-4930-93f4-ecd2cef60d3c.png">
