### PR TITLE
fix: 🐛 fixed outline appearing underneath tabs

### DIFF
--- a/src/components/tabs/collection-tabs.tsx
+++ b/src/components/tabs/collection-tabs.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import * as Tabs from '@radix-ui/react-tabs';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ActivityTable } from '../tables';
 import { CollectionItems } from '../items';
@@ -9,6 +8,7 @@ import {
   TabsTrigger,
   TabsList,
   TabsContentWrapper,
+  TabsContent,
 } from './styles';
 import { Filters } from '../filters';
 import { Icon } from '../icons';
@@ -54,15 +54,15 @@ export const CollectionTabs = () => {
           {t('translation:tabs.activity')}
         </TabsTrigger>
       </TabsList>
-      <Tabs.Content value="items">
+      <TabsContent value="items">
         <TabsContentWrapper>
           <Filters />
           <CollectionItems />
         </TabsContentWrapper>
-      </Tabs.Content>
-      <Tabs.Content value="activity">
+      </TabsContent>
+      <TabsContent value="activity">
         <ActivityTable />
-      </Tabs.Content>
+      </TabsContent>
     </TabsRoot>
   );
 };

--- a/src/components/tabs/styles.ts
+++ b/src/components/tabs/styles.ts
@@ -69,3 +69,9 @@ export const TabsContentWrapper = styled('div', {
     borderTop: '1px solid $borderColor',
   },
 });
+
+export const TabsContent = styled(Tabs.Content, {
+  '&:focus': {
+    outline: 'none',
+  },
+});


### PR DESCRIPTION
## Why?

The divider underneath tabs is randomly selectable

## How?

- Created style component for `Tabs.Content`
- Set the outline on focus to none

## Tickets?

- [Notion](https://www.notion.so/The-divider-ref-screenshot-is-randomly-selectable-with-tab-890fdcc6399d4e2e8dc14b7eb8bc4203)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?
Issue:
https://user-images.githubusercontent.com/51888121/170490723-c9a56ca4-4bc9-4eb7-8287-d883ed71e169.mov

Fix:
<img width="1440" alt="Screenshot 2022-05-26 at 13 35 31" src="https://user-images.githubusercontent.com/51888121/170490821-9260b239-eb41-48ae-aa9a-c0a8aba51aac.png">
