### PR TITLE
refactor: 💡 increased make offer modal screen time

### DIFF
--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -10,6 +10,7 @@ import { AppLog } from '../../../../utils/log';
 import { parseAmountToE8S } from '../../../../utils/formatters';
 import { errorMessageHandler } from '../../../../utils/error';
 import { KyasshuUrl } from '../../../../integrations/kyasshu';
+import { delayAction } from '../../../../utils/delay-action';
 
 export type MakeOfferProps = DefaultCallbacks & MakeOffer;
 
@@ -84,7 +85,7 @@ export const makeOffer = createAsyncThunk<
 
     // We call the Cap Sync process
     // but we don't have to wait for the response
-    await new Promise(resolve => setTimeout(resolve, 5000));
+    await delayAction(5000);
     await axios.get(KyasshuUrl.getCAPSync());
     return {
       id,

--- a/src/utils/delay-action.ts
+++ b/src/utils/delay-action.ts
@@ -1,0 +1,1 @@
+export const delayAction = (time: number) => new Promise(resolve => setTimeout(resolve, time));


### PR DESCRIPTION
## Why?

The make offer success modal disappears way too fast.

## How?

- Added in a set timeout 5 seconds delay

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=e53f56d184474147a77153c9ffd8c45e)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/170953111-a36c223d-894c-4332-b73b-c71a62c7ef28.mov
