### PR TITLE
refactor: 💡 set up skeletons for details page

### DIFF
--- a/src/components/nft-details/nft-details-skeleton.tsx
+++ b/src/components/nft-details/nft-details-skeleton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import TraitsListLoader from './TraitsListLoader';
+import {
+  DetailsContainer,
+  PreviewContainer,
+  PreviewImageSkeleton,
+  AccordionSkeletion,
+  Wrapper
+} from './styles';
+
+const NFTDetailsSkeleton = () => {
+  return (
+    <Wrapper>
+      <PreviewContainer>
+        <PreviewImageSkeleton />
+        <TraitsListLoader />
+      </PreviewContainer>
+      <DetailsContainer>
+        <AccordionSkeletion />
+        <AccordionSkeletion />
+      </DetailsContainer>
+    </Wrapper>
+  );
+};
+
+export default NFTDetailsSkeleton;

--- a/src/components/nft-details/nft-details.tsx
+++ b/src/components/nft-details/nft-details.tsx
@@ -31,6 +31,7 @@ import { parseE8SAmountToWICP } from '../../utils/formatters';
 import { extractTraitData } from '../../store/features/filters/async-thunks/get-filter-traits';
 import TraitsListLoader from './TraitsListLoader';
 import { roundOffDecimalValue } from '../../utils/nfts';
+import NFTDetailsSkeleton from './nft-details-skeleton';
 
 // type CurrentListing = {
 //   seller: string;
@@ -204,7 +205,7 @@ export const NftDetails = () => {
           </DetailsContainer>
         </Wrapper>
       ) : (
-        <Wrapper centered>Loading...</Wrapper>
+        <NFTDetailsSkeleton />
       )}
     </Container>
   );

--- a/src/components/nft-details/styles.ts
+++ b/src/components/nft-details/styles.ts
@@ -80,3 +80,17 @@ export const NFTTraitsChipSkeleton = styled(SkeletonBox, {
     },
   },
 });
+
+export const PreviewImageSkeleton = styled(SkeletonBox, {
+  width: '100%',
+  maxWidth: '480px',
+  height: '425px',
+  marginBottom: '10px',
+});
+
+export const AccordionSkeletion = styled(SkeletonBox, {
+  width: '100%',
+  maxWidth: '670px',
+  height: '214px',
+  marginBottom: '25px',
+});


### PR DESCRIPTION
## Why?

The loading state of nft details page only shows a loading text

## How?

- Created new component for the details page skeleton.
- Rendered component in place of loading text previously being used.

## Tickets?

- [Notion](https://www.notion.so/The-loading-when-landing-directly-on-nft-page-can-be-improved-de25fa52343c4e3abfff8f7ede5fbf59)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-05-29 at 15 35 50" src="https://user-images.githubusercontent.com/51888121/170953367-aa84e812-05e8-4bca-806a-9d7859352d02.png">

<img width="1440" alt="Screenshot 2022-05-29 at 15 35 42" src="https://user-images.githubusercontent.com/51888121/170953333-60594cbd-49ab-4877-a901-8f80f1013732.png">
