### PR TITLE
fix: 🐛 select traits with identical values

### DIFF
--- a/src/components/core/accordions/checkbox-filter-accordion.tsx
+++ b/src/components/core/accordions/checkbox-filter-accordion.tsx
@@ -21,30 +21,34 @@ export type CheckboxFilterAccordionProps = {
 };
 
 export const CheckboxFilterAccordion = ({
-  id = 'item-1',
+  id,
   checkboxData,
 }: CheckboxFilterAccordionProps) => {
   const dispatch = useAppDispatch();
   const { traits } = useFilterStore();
   const [isAccordionOpen, setIsAccordionOpen] = useState(true);
-  const filterValueExists = (traitsValue: string) =>
+  const filterValueExists = (
+    traitsValue: string,
+    checkboxKey: string,
+  ) =>
     traits.some(
       (trait) =>
         trait.values.includes(traitsValue) &&
-        trait.key === checkboxData.key,
+        trait.key === checkboxKey,
     );
   const traitsCount = traits.find(
     (trait) => trait.name === checkboxData.name,
   )?.values?.length;
 
   const handleSelectedFilters = (e: any) => {
-    const checkFilterValueExists = filterValueExists(e.target.value);
+    const [key, value] = e.target.value.split('-');
+    const checkFilterValueExists = filterValueExists(value, key);
 
     if (checkFilterValueExists) {
       dispatch(
         filterActions.removeTraitsFilter({
-          value: e.target.value,
-          key: checkboxData.key,
+          value: value,
+          key: key,
         }),
       );
       return;
@@ -52,9 +56,9 @@ export const CheckboxFilterAccordion = ({
 
     dispatch(
       filterActions.applytraits({
-        key: checkboxData.key,
+        key: key,
         name: checkboxData.name,
-        values: [e.target.value],
+        values: [value],
       }),
     );
   };
@@ -76,7 +80,9 @@ export const CheckboxFilterAccordion = ({
         >
           <p>
             {checkboxData.key}
-            {traitsCount && <ItemCount>{`(${traitsCount})`}</ItemCount>}
+            {traitsCount && (
+              <ItemCount>{`(${traitsCount})`}</ItemCount>
+            )}
           </p>
 
           <Icon
@@ -89,12 +95,15 @@ export const CheckboxFilterAccordion = ({
           <Form>
             {checkboxData.values.map((data: any) => (
               <Checkbox
-                key={data.value}
-                value={data.value}
+                key={`${checkboxData.key}-${data.value}`}
+                value={`${checkboxData.key}-${data.value}`}
                 percentage={data.rarity}
                 occurence={data.occurance}
                 handleSelectedFilters={handleSelectedFilters}
-                filterValueExists={filterValueExists}
+                filterValueExists={filterValueExists(
+                  data.value,
+                  checkboxData.key,
+                )}
               />
             ))}
           </Form>

--- a/src/components/core/checkbox/checkbox.tsx
+++ b/src/components/core/checkbox/checkbox.tsx
@@ -5,7 +5,7 @@ import { Wrapper } from './styles';
 export type CheckboxProps = {
   title?: string;
   value: string; // Red
-  filterValueExists: (value: string) => boolean;
+  filterValueExists: boolean;
   percentage: string; // 1291 (12.9%)
   occurence: string;
   handleSelectedFilters: (
@@ -29,10 +29,10 @@ export const Checkbox = ({
         value={value}
         onClick={handleSelectedFilters}
         // checks if value exists in array and sets checked to true
-        checked={filterValueExists(value)}
+        checked={filterValueExists}
       />
       <span />
-      {value}
+      {value.split('-')[1]}
     </label>
     <span>{`${occurence} (${roundOffDecimalValue(Number(percentage), 1)}%)`}</span>
   </Wrapper>

--- a/src/components/filters/filters.tsx
+++ b/src/components/filters/filters.tsx
@@ -362,7 +362,7 @@ export const Filters = () => {
                       <CheckboxFilterAccordion
                         key={checkboxData.name}
                         checkboxData={checkboxData}
-                        id={checkboxData.name}
+                        id={checkboxData.key}
                       />
                     ),
                   )


### PR DESCRIPTION
## Why?

Same filter names are failing to be selected on different traits

## How?

- Set up custom key/value to ensure every key/value is unique

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=e5c185556be243ec8af8e4a8f48d368a)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/171073120-9bffd795-aa69-4434-b464-911c61d66a31.mov
