### PR TITLE
fix: 🐛 cancel offer button has no space around it

### DIFF
--- a/src/components/core/buttons/styles.ts
+++ b/src/components/core/buttons/styles.ts
@@ -53,7 +53,6 @@ export const Button = styled('button', {
 
     size: {
       small: {
-        minWidth: '120px',
         fontSize: '16px',
         lineHeight: '19px',
         borderWidth: '1px',

--- a/src/components/modals/cancel-offer-modal.tsx
+++ b/src/components/modals/cancel-offer-modal.tsx
@@ -85,7 +85,9 @@ export const CancelOfferModal = ({
       <DialogPrimitive.Trigger asChild>
         <CancelOfferModalTrigger largeButton={largeTriggerButton}>
           <ActionButton type="secondary" size="small">
-            {t('translation:buttons.action.cancelOffer')}
+            {largeTriggerButton
+              ? t('translation:buttons.action.cancelOffer')
+              : t('translation:buttons.action.cancel')}
           </ActionButton>
         </CancelOfferModalTrigger>
       </DialogPrimitive.Trigger>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -43,7 +43,8 @@
       "apply": "Apply",
       "myOffers": "My Offers",
       "disconnect": "Disconnect",
-      "editOffer": "Edit Offer"
+      "editOffer": "Edit Offer",
+      "cancel": "Cancel"
     }
   },
   "dropdown": {
@@ -289,4 +290,3 @@
     "retryMessage": "click here to retry."
   }
 }
-


### PR DESCRIPTION
## Why?

The button text being rendered was incorrect and was taking up all of the space in the button.

## How?

- Rendered correct button text based on conditional.

## Tickets?

- [Notion](https://www.notion.so/Nacho-Feedback-31-5-20a6d1cd7e484c23a2bc3b6d577f846f#65912466f6a94887bfcb1d70dbbcc45b)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-05-31 at 15 50 39" src="https://user-images.githubusercontent.com/51888121/171203184-152f20b0-712d-42d4-bff6-f7224e166bc2.png">
