### PR TITLE
refactor: 💡 cleaned up nft preview card

### DIFF
--- a/src/components/core/cards/nft-card/nft-card.tsx
+++ b/src/components/core/cards/nft-card/nft-card.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, { useRef } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { CardOptionsDropdown } from '../../dropdown';
 import {
@@ -15,6 +14,7 @@ import {
   NftDataText,
   ActionText,
   PriceInActionSheet,
+  RouterLink,
 } from './styles';
 import wicpLogo from '../../../../assets/wicp.svg';
 import {
@@ -187,12 +187,16 @@ export const NftCard = React.memo(
     return (
       <CardContainer ref={containerRef}>
         <CardWrapper>
-          <RouterLink to={`/nft/${data.id}`} className="card-router">
+          <RouterLink
+            to={`/nft/${data.id}`}
+            className="card-router"
+            previewCard={previewCard}
+          >
             <Flex>
               <OwnedCardText>
                 {owned ? `${t('translation:nftCard.owned')}` : ''}
               </OwnedCardText>
-              <CardOptionsDropdown data={data} />
+              {!previewCard && <CardOptionsDropdown data={data} />}
             </Flex>
             <Media
               containerRef={containerRef}

--- a/src/components/core/cards/nft-card/styles.ts
+++ b/src/components/core/cards/nft-card/styles.ts
@@ -1,4 +1,5 @@
 import { styled, keyframes } from '../../../../stitches.config';
+import { Link } from 'react-router-dom';
 import { ImagePreload } from '../../../image-preload';
 import { NumberTooltip } from '../../../number-tooltip';
 import { VideoPreload } from '../../../video-preload';
@@ -162,4 +163,14 @@ export const HoverMessageContainer = styled('span', {
 
   backgroundColor: '$backgroundColor',
   color: '$mainTextColor',
+});
+
+export const RouterLink = styled(Link, {
+  variants: {
+    previewCard: {
+      true: {
+        pointerEvents: 'none',
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Why?

Nft preview card redirects to the details page when clicked.
Nft preview card shows dropdown icon that isn't being used.

## How?

- Removed copy link dropdown icon from preview card
- Disabled preview card from redirecting to the nft details page on click

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=ea069d6078d64784b3088c025a2a9bd0)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/171211003-acefefb3-a8d3-4097-8586-c68ba880b7ac.mov
