### PR TITLE
fix: 🐛 refresh page when logo is clicked

### DIFF
--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,4 +1,4 @@
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useCallback } from 'react';
 import {
@@ -30,6 +30,7 @@ export const NavBar = () => {
   const dispatch = useAppDispatch();
   const { theme } = useThemeStore();
   const { showAlerts } = useSettingsStore();
+  const { pathname } = useLocation();
   const isLightTheme = theme === 'lightTheme';
 
   const changeThemeHandler = useCallback(() => {
@@ -44,7 +45,10 @@ export const NavBar = () => {
 
   return (
     <Container showAlerts={showAlerts}>
-      <RouterLink to="/">
+      <RouterLink
+        to="/"
+        onClick={() => pathname === '/' && window.location.reload()}
+      >
         <LogoContainer>
           <LogoIcon
             src={isLightTheme ? jelly : jellyDark}


### PR DESCRIPTION
## Why?

Clicking on the jelly logo on the homepage doesn't refresh page

## How?

- Added a refresh function that runs on the homepage

## Tickets?

- [Notion](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=1a75363e97e24340b4cac149e7f0abbd)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/171223659-e7e9c1c2-2928-45e2-8f61-cd2791968219.mov
