### PR TITLE
style: 💅🏼 added transition to accordion dropdown

### DIFF
--- a/src/components/core/accordions/styles.ts
+++ b/src/components/core/accordions/styles.ts
@@ -1,6 +1,16 @@
 import * as Accordion from '@radix-ui/react-accordion';
-import { styled } from '../../../stitches.config';
+import { styled, keyframes } from '../../../stitches.config';
 import { SkeletonBox } from '../skeleton';
+
+const slideDown = keyframes({
+  from: { maxHeight: 0 },
+  to: { maxHeight: 'var(--radix-accordion-content-height)' },
+});
+
+const slideUp = keyframes({
+  from: { height: 'var(--radix-accordion-content-height)' },
+  to: { height: 0 },
+});
 
 export const AccordionStyle = styled(Accordion.Root, {
   border: '2px solid $borderColor',
@@ -170,6 +180,7 @@ export const FlexRight = styled('div', {
 
 export const AccordionTrigger = styled(Accordion.Trigger, {
   color: '$mainTextColor',
+
   variants: {
     backgroundColor: {
       open: {
@@ -261,13 +272,23 @@ export const AccordionTrigger = styled(Accordion.Trigger, {
 
 export const AccordionContent = styled(Accordion.Content, {
   color: '$mainTextColor',
+  overflow: 'hidden',
+
+  '&[data-state="open"]': {
+    animation: `${slideDown} 700ms cubic-bezier(0.87, 0, 0.13, 1) forwards`,
+  },
+
+  '&[data-state="closed"]': {
+    animation: `${slideUp} 600ms cubic-bezier(0.87, 0, 0.13, 1) forwards`,
+  },
+
   variants: {
     backgroundColor: {
       open: {
         background: '$openAccordion',
       },
       notopen: {
-        backgroundColor: 'white',
+        backgroundColor: '$closeAccordion',
       },
       none: {
         backgroundColor: 'unset',


### PR DESCRIPTION
## Why?

[We could add a transition to open about crowns collapsable](https://www.notion.so/Nacho-Feedback-31-5-20a6d1cd7e484c23a2bc3b6d577f846f#ef3738130d8c49228470142b584c5443)

## How?

- Added a keyframe from the stitches library
- Added animation to target style component

## Tickets?

- [Notion](https://www.notion.so/Nacho-Feedback-31-5-20a6d1cd7e484c23a2bc3b6d577f846f#ef3738130d8c49228470142b584c5443)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/171315388-945658a6-ccf5-4a4d-ba69-324907a1025f.mov
