### PR TITLE
refactor: 💡 changed colour of checkbox rarity values

### DIFF
--- a/src/components/core/checkbox/checkbox.tsx
+++ b/src/components/core/checkbox/checkbox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { roundOffDecimalValue } from '../../../utils/nfts';
-import { Wrapper } from './styles';
+import { Wrapper, RarityValue } from './styles';
 
 export type CheckboxProps = {
   title?: string;
@@ -34,6 +34,6 @@ export const Checkbox = ({
       <span />
       {value.split('-')[1]}
     </label>
-    <span>{`${occurence} (${roundOffDecimalValue(Number(percentage), 1)}%)`}</span>
+    <RarityValue>{`${occurence} (${roundOffDecimalValue(Number(percentage), 1)}%)`}</RarityValue>
   </Wrapper>
 );

--- a/src/components/core/checkbox/styles.ts
+++ b/src/components/core/checkbox/styles.ts
@@ -26,7 +26,7 @@ export const Wrapper = styled('div', {
     },
 
     '& input[type="checkbox"] + span:before': {
-      content: "\\00a0",
+      content: '\\00a0',
       marginRight: '8px',
       marginLeft: '0px',
       border: '1px solid #777E8F',
@@ -57,18 +57,18 @@ export const Wrapper = styled('div', {
 
     '& input[type="checkbox"]:checked + span:after': {
       fontWeight: 'bold',
-      color: 'white'
-    },
-
-    '& span': {
-      fontStyle: 'normal',
-      fontWeight: '500',
-      fontSize: '13px',
-      lineHeight: '20px',
-      display: 'flex',
-      alignItems: 'center',
-      textAlign: 'right',
-      color: '#777E8F',
+      color: 'white',
     },
   },
+});
+
+export const RarityValue = styled('span', {
+  color: '$regentGrey',
+  fontStyle: 'normal',
+  fontWeight: '500',
+  fontSize: '14px',
+  lineHeight: '20px',
+  display: 'flex',
+  alignItems: 'center',
+  textAlign: 'right',
 });

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -46,6 +46,7 @@ export const {
       iconGrey: '#767D8F',
       lightYellow: '#ffd71926',
       paleYellow: '#987E00',
+      regentGrey: '#777E8F',
     },
     space: {},
     fonts: {},


### PR DESCRIPTION
## Why?

Colour and boldness of the quantities of checked checkboxes did not match figma design

## How?

- Changed the rarity value text colour

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#93de2d6580dc4a29babc54adb3fa832a)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="387" alt="Screenshot 2022-06-01 at 03 37 50" src="https://user-images.githubusercontent.com/51888121/171316779-80e2e9e2-be90-4c63-b437-2518b3fa612a.png">
