### PR TITLE
style: 💄 nft card image and video fitting as square

### DIFF
--- a/src/components/core/cards/nft-card/styles.ts
+++ b/src/components/core/cards/nft-card/styles.ts
@@ -1,5 +1,5 @@
-import { styled, keyframes } from '../../../../stitches.config';
 import { Link } from 'react-router-dom';
+import { styled, keyframes } from '../../../../stitches.config';
 import { ImagePreload } from '../../../image-preload';
 import { NumberTooltip } from '../../../number-tooltip';
 import { VideoPreload } from '../../../video-preload';
@@ -38,13 +38,12 @@ export const CardWrapper = styled('div', {
 
 export const MediaWrapper = styled('div', {
   position: 'relative',
-  minHeight: '175px',
-  height: '175px',
+  height: '207px',
   margin: '10px -15px',
 });
 
 export const PreviewDetails = styled('div', {
-  minHeight: '175px',
+  minHeight: '207px',
   width: '100%',
   height: '100%',
 });

--- a/src/components/core/infinite-list/virtualized-grid.tsx
+++ b/src/components/core/infinite-list/virtualized-grid.tsx
@@ -4,11 +4,11 @@ import useVirtual from 'react-cool-virtual';
 
 const DefaultProps = {
   width: 210,
-  height: 300,
+  height: 348,
   headerOffset: 76,
   columns: 3,
-  scrollThreshold: 300,
-  rowSpacing: 1.15,
+  scrollThreshold: 348,
+  rowSpacing: 1.06,
   padding: 15,
   throttlingInterval: 300,
 };


### PR DESCRIPTION
## Why?

In the NFT Card, the image and video should be square.

## Demo?

https://user-images.githubusercontent.com/236752/171379054-c5e472cb-e8c4-469b-b5e7-5bf32a6822dd.mp4


