### PR TITLE
refactor: 💡 reduced trait chip spacing

### DIFF
--- a/src/components/core/chips/styles.ts
+++ b/src/components/core/chips/styles.ts
@@ -31,7 +31,7 @@ export const TraitChipContainer = styled('div', {
   boxSizing: 'border-box',
   display: 'flex',
   alignItems: 'center',
-  padding: '12px 15px',
+  padding: '12px 10px',
   borderRadius: '14px',
   background: '$chipsBackgroundColor',
   color: '$chipsTextColor',

--- a/src/components/nft-details/styles.ts
+++ b/src/components/nft-details/styles.ts
@@ -65,7 +65,7 @@ export const NFTTraitsChipSkeleton = styled(SkeletonBox, {
   boxSizing: 'border-box',
   display: 'flex',
   alignItems: 'center',
-  padding: '12px 15px',
+  padding: '12px 10px',
   borderRadius: '14px',
   minWidth: '150px',
   border: '1.5px solid $borderColor',


### PR DESCRIPTION
## Why?

The spacing on the trait chip doesn't match the figma design.

## How?

- Reduced the padding of the trait chips.

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#2f90db5325304c9bb4967eae3d70549e)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1053" alt="Screenshot 2022-06-01 at 12 10 14" src="https://user-images.githubusercontent.com/51888121/171391575-d5230718-edf8-4851-b81f-57eb37da824a.png">
