### PR TITLE
fix: 🐛 disabled button actions, should not allow keyboard

### DIFF
--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -1,4 +1,3 @@
-// WIP
 import { useMemo, useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';


### PR DESCRIPTION
## Why?

When buttons are disabled, the keyboard keying should not be allowed to perform actions

## Demo?

https://user-images.githubusercontent.com/236752/171406585-d2b6d748-11df-4d6c-a660-9316d44437c4.mp4


