### PR TITLE
refactor: 💡 cleaned up offers screen

### DIFF
--- a/src/components/core/buttons/styles.ts
+++ b/src/components/core/buttons/styles.ts
@@ -62,6 +62,12 @@ export const Button = styled('button', {
         padding: '8px 35px',
       },
     },
+
+    fontWeight: {
+      light: {
+        fontWeight: 500,
+      }
+    }
   },
   cursor: 'pointer',
   padding: '8px 12px',

--- a/src/components/core/table-cells/price-details-cell.tsx
+++ b/src/components/core/table-cells/price-details-cell.tsx
@@ -21,6 +21,7 @@ export const PriceDetailsCell = ({
   <PriceDetails>
     <WICPContainer tableType={tableType}>
       <WICPText tableType={tableType}>{wicp ? wicp : '-'}</WICPText>
+      <WICPText tableType={tableType}>{wicp ? "WICP" : '-'}</WICPText>
       {wicp && <WICPLogo src={wicpIcon} alt="wicp" />}
     </WICPContainer>
     {price && <PriceText tableType={tableType}>{price}</PriceText>}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -26,6 +26,8 @@ import { FaSearch } from '@react-icons/all-files/fa/FaSearch';
 import { GoVerified } from '@react-icons/all-files/go/GoVerified';
 import { FaRegHandPaper } from '@react-icons/all-files/fa/FaRegHandPaper';
 import { IoWarningOutline } from '@react-icons/all-files/io5/IoWarningOutline';
+import { FiUpload } from '@react-icons/all-files/fi/FiUpload';
+import { FiDownload } from '@react-icons/all-files/fi/FiDownload';
 
 import { PlugIcon, AppNameIcon, SpinnerIcon } from './custom';
 
@@ -59,6 +61,8 @@ export const Icons = {
   verified: GoVerified,
   'hand-paper': FaRegHandPaper,
   spinner: SpinnerIcon,
+  upload: FiUpload,
+  download: FiDownload,
 
   plug: PlugIcon,
   'app-name': AppNameIcon,

--- a/src/components/modals/accept-offer-modal.tsx
+++ b/src/components/modals/accept-offer-modal.tsx
@@ -50,6 +50,7 @@ export interface AcceptOfferProps {
   formattedPrice: string;
   offerFrom: string;
   nftTokenId?: string;
+  actionButtonProp?: string;
 }
 
 /* --------------------------------------------------------------------------
@@ -61,6 +62,7 @@ export const AcceptOfferModal = ({
   formattedPrice,
   offerFrom,
   nftTokenId,
+  actionButtonProp
 }: AcceptOfferProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -145,7 +147,11 @@ export const AcceptOfferModal = ({
       */}
       <DialogPrimitive.Trigger asChild>
         <AcceptOfferModalTrigger>
-          <ActionButton type="outline" size="small">
+          <ActionButton
+            type="outline"
+            size="small"
+            fontWeight={actionButtonProp ? "light" : undefined}
+          >
             {t('translation:buttons.action.acceptOffer')}
           </ActionButton>
         </AcceptOfferModalTrigger>

--- a/src/components/modals/cancel-offer-modal.tsx
+++ b/src/components/modals/cancel-offer-modal.tsx
@@ -84,7 +84,11 @@ export const CancelOfferModal = ({
       */}
       <DialogPrimitive.Trigger asChild>
         <CancelOfferModalTrigger largeButton={largeTriggerButton}>
-          <ActionButton type="secondary" size="small">
+          <ActionButton
+            type="secondary"
+            size="small"
+            fontWeight={largeTriggerButton ? undefined : 'light'}
+          >
             {largeTriggerButton
               ? t('translation:buttons.action.cancelOffer')
               : t('translation:buttons.action.cancel')}

--- a/src/components/tables/my-offers-table.tsx
+++ b/src/components/tables/my-offers-table.tsx
@@ -65,6 +65,7 @@ export const MyOffersTable = ({ offersType }: MyOffersTableProps) => {
   const ownerTokenIdentifiers = useSelector(
     (state: RootState) => state.crowns.ownerTokenIdentifiers,
   );
+
   const recentlyAcceptedOffers = useSelector(
     (state: RootState) => state.marketplace.recentlyAcceptedOffers,
   );
@@ -257,6 +258,7 @@ export const MyOffersTable = ({ offersType }: MyOffersTableProps) => {
               }
               offerFrom={fromDetails.address}
               nftTokenId={item.tokenId.toString()}
+              actionButtonProp="light"
             />
           </ButtonWrapper>
         ),

--- a/src/views/OffersView/index.tsx
+++ b/src/views/OffersView/index.tsx
@@ -8,9 +8,11 @@ import {
   Title,
   ButtonListWrapper,
   ButtonDetailsWrapper,
+  StyledIcons,
 } from './styles';
 import { OfferTypeStatusCodes } from '../../constants/my-offers';
 import { useSettingsStore } from '../../store';
+import { NftMetadataBackground } from '../../components/collection-overview/styles';
 
 /* --------------------------------------------------------------------------
  * Offers View Component
@@ -26,11 +28,13 @@ const OffersView = () => {
 
   return (
     <Container showAlerts={showAlerts}>
+      <NftMetadataBackground />
       <TitleWrapper>
         <Title>{t('translation:offers.myOffers')}</Title>
         <ButtonListWrapper>
           <ButtonDetailsWrapper>
             <ActionButton
+              fontWeight="light"
               type={
                 offersType === OfferTypeStatusCodes.OffersReceived
                   ? 'outline'
@@ -40,11 +44,13 @@ const OffersView = () => {
                 setOffersType(OfferTypeStatusCodes.OffersReceived);
               }}
             >
+              <StyledIcons icon="download" />
               {t('translation:offers.offersReceived')}
             </ActionButton>
           </ButtonDetailsWrapper>
           <ButtonDetailsWrapper>
             <ActionButton
+              fontWeight="light"
               type={
                 offersType === OfferTypeStatusCodes.OffersMade
                   ? 'outline'
@@ -54,6 +60,7 @@ const OffersView = () => {
                 setOffersType(OfferTypeStatusCodes.OffersMade);
               }}
             >
+              <StyledIcons icon="upload" />
               {t('translation:offers.offersMade')}
             </ActionButton>
           </ButtonDetailsWrapper>

--- a/src/views/OffersView/styles.ts
+++ b/src/views/OffersView/styles.ts
@@ -1,3 +1,4 @@
+import { Icon } from '../../components';
 import { styled } from '../../stitches.config';
 
 export const Container = styled('div', {
@@ -36,4 +37,8 @@ export const ButtonListWrapper = styled('div', {
 export const ButtonDetailsWrapper = styled('div', {
   height: '44px',
   marginLeft: '15px',
+});
+
+export const StyledIcons = styled(Icon, {
+  marginRight: '10px',
 });


### PR DESCRIPTION
## Why?

Offers screen UI doesn't match figma design

## How?

- Set up prop to reduce the font weight on the buttons
- Added icons to the buttons
- Added 'WICP' text to the price

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#f4fe8462cd1840989a05c5e16b497bb3)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-06-01 at 16 03 59" src="https://user-images.githubusercontent.com/51888121/171446775-4519f438-144d-4843-804e-5d803a205c5d.png">
