### PR TITLE
fix: 🐛 added space beneath filtered traits

### DIFF
--- a/src/components/core/chips/styles.ts
+++ b/src/components/core/chips/styles.ts
@@ -42,7 +42,7 @@ export const TraitChipContainer = styled('div', {
       filtered: {
         background: 'rgba(34, 83, 255, 0.1)',
         border: '1.5px solid #87A1FF',
-        margin: '0px 10px 0px 0px',
+        margin: '0px 10px 10px 0px',
       },
 
       nft: {


### PR DESCRIPTION
## Why?

There was no spacing below nft trait chips

## How?

- Added margin to the bottom of the chips

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#2a8cd9c9ffe942f7beffd201b9c30d0d)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1053" alt="Screenshot 2022-06-01 at 16 57 44" src="https://user-images.githubusercontent.com/51888121/171448378-1da5c737-ea9f-42d4-9246-2f2f413a3c31.png">
