### PR TITLE
fix: activity table data parsing, remove extra WICP text

### DIFF
--- a/src/components/tables/nft-activity-table.tsx
+++ b/src/components/tables/nft-activity-table.tsx
@@ -57,7 +57,7 @@ export const NFTActivityTable = () => {
         Header: t('translation:tables.titles.price'),
         accessor: ({ price }: RowProps) => (
           <PriceDetailsCell
-            wicp={`${price} WICP`}
+            wicp={`${price}`}
             // Obs: we don't know the historical market price at time of direct buy
             // so we are not going to display it, as by computing the current market price
             // would be misleading


### PR DESCRIPTION
## Why?

Data was not being parsed correctly (static array access)

## How?

- parse details into an object with `Object.fromEntries`
- access fields with their name instead of static location
- remove extra `WICP` text on prices

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

![Screenshot_2022-06-02_01:33:14](https://user-images.githubusercontent.com/8976745/171628770-797f2e89-ca51-4fb3-b88f-ab4fa239b001.png)

