### PR TITLE
feat: 🎸 added spinner to search bar

### DIFF
--- a/src/components/search/global-search.tsx
+++ b/src/components/search/global-search.tsx
@@ -22,7 +22,7 @@ import {
   WICPLogo,
   PriceText,
   SubText,
-  Loading,
+  SpinnerIcon,
 } from './styles';
 import {
   filterActions,
@@ -69,6 +69,7 @@ export const GlobalSearch = () => {
     }, DEBOUNCE_TIMEOUT_MS),
     [loadedNFTS],
   );
+
   const handleSearch = (value: string) => {
     if (!value) {
       dispatch(filterActions.setSearchResults([]));
@@ -175,7 +176,12 @@ export const GlobalSearch = () => {
             {t('translation:common.noRecentSearch')}
           </ItemsEmptyContainer>
         )}
-        {loadingSearch && <Loading />}
+        {loadingSearch && (
+          <SpinnerIcon
+            icon="spinner"
+            extraIconProps={{ size: '32px' }}
+          />
+        )}
       </ModalContent>
     </DialogPrimitive.Root>
   );

--- a/src/components/search/styles.ts
+++ b/src/components/search/styles.ts
@@ -1,6 +1,6 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { styled, keyframes } from '../../stitches.config';
-import Spinner from '../core/spinner';
+import { Icon } from '../icons';
 
 const overlayShow = keyframes({
   '0%': {
@@ -223,6 +223,9 @@ export const SubText = styled('span', {
   },
 });
 
-export const Loading = styled(Spinner, {
-  padding: '10px',
+export const SpinnerIcon = styled(Icon, {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  marginLeft: '-25px',
 });


### PR DESCRIPTION
## Why?

There was no spinner to indicate the search bar's loading state.

## How?

- Added spinner icon to search bar component.

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#e78fc5f9acbe4043a8ee8a40f614475e)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/171637828-5fad365a-101f-4a86-b394-64f2a8fb71a1.mov
