### PR TITLE
style: 💅🏼 search bar spinner

### DIFF
--- a/src/components/search/global-search.tsx
+++ b/src/components/search/global-search.tsx
@@ -22,7 +22,7 @@ import {
   WICPLogo,
   PriceText,
   SubText,
-  SpinnerIcon,
+  LoadingWrapper,
 } from './styles';
 import {
   filterActions,
@@ -31,6 +31,7 @@ import {
   useNFTSStore,
 } from '../../store';
 import { formatPriceValue } from '../../utils/formatters';
+import { SpinnerIcon } from '../icons/custom';
 
 const DEBOUNCE_TIMEOUT_MS = 400;
 
@@ -177,10 +178,9 @@ export const GlobalSearch = () => {
           </ItemsEmptyContainer>
         )}
         {loadingSearch && (
-          <SpinnerIcon
-            icon="spinner"
-            extraIconProps={{ size: '32px' }}
-          />
+          <LoadingWrapper>
+            <SpinnerIcon />
+          </LoadingWrapper>
         )}
       </ModalContent>
     </DialogPrimitive.Root>

--- a/src/components/search/styles.ts
+++ b/src/components/search/styles.ts
@@ -1,6 +1,5 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { styled, keyframes } from '../../stitches.config';
-import { Icon } from '../icons';
 
 const overlayShow = keyframes({
   '0%': {
@@ -223,7 +222,7 @@ export const SubText = styled('span', {
   },
 });
 
-export const SpinnerIcon = styled(Icon, {
+export const LoadingWrapper = styled('div', {
   position: 'absolute',
   top: '50%',
   left: '50%',


### PR DESCRIPTION
## Why?

The spinner to indicate loading state was not styled.

## How?

- Styled spinner that was added to the search bar.

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#e78fc5f9acbe4043a8ee8a40f614475e)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/171637828-5fad365a-101f-4a86-b394-64f2a8fb71a1.mov
