### PR TITLE
refactor: 💡 removed scrollbar from search modal content

### DIFF
--- a/src/components/search/styles.ts
+++ b/src/components/search/styles.ts
@@ -85,6 +85,12 @@ export const ItemsListContainer = styled('div', {
   padding: '0px 0px 10px',
   maxHeight: '325px',
   overflow: 'scroll',
+  msOverflowStyle: 'none',
+  scrollbarWidth: 'none',
+
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
 });
 
 export const ItemDetailsWrapper = styled('div', {


### PR DESCRIPTION
## Why?

Scrollbar showing when user scrolls through the search bar modal content.

## How?

- Removed the scollbar.

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#33321755d6f74ccea56220acf0032b5f)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

**Issue:**

https://user-images.githubusercontent.com/51888121/171738028-193f6141-9fe3-4f47-bbf6-fd9e0b612c4c.mov

**Fix:**

https://user-images.githubusercontent.com/51888121/171738085-2bde13d6-e9ee-4e25-af92-bcb293ab6097.mov
