### PR TITLE
refactor: 💡 added not allowed cursor to disabled button

### DIFF
--- a/src/components/core/buttons/action-button.tsx
+++ b/src/components/core/buttons/action-button.tsx
@@ -1,13 +1,15 @@
-import { Button } from './styles';
+import { Button, Wrapper } from './styles';
 
 export type ActionButtonProps = React.ComponentProps<typeof Button>;
 
 export const ActionButton = (props: any) => (
-  <Button
-    {...props}
-    onKeyDown={(ev) =>
-      // eslint-disable-next-line react/destructuring-assignment
-      props.disabled && ev.preventDefault()
-    }
-  />
+  <Wrapper disabled={props.disabled}>
+    <Button
+      {...props}
+      onKeyDown={(ev) =>
+        // eslint-disable-next-line react/destructuring-assignment
+        props.disabled && ev.preventDefault()
+      }
+    />
+  </Wrapper>
 );

--- a/src/components/core/buttons/styles.ts
+++ b/src/components/core/buttons/styles.ts
@@ -1,5 +1,20 @@
 import { styled } from '../../../stitches.config';
 
+export const Wrapper = styled('div', {
+  width: '100%',
+  height: '100%',
+  minWidth: '98px',
+  minHeight: '33px',
+
+  variants: {
+    disabled: {
+      true: {
+        cursor: 'not-allowed',
+      },
+    },
+  },
+});
+
 export const Button = styled('button', {
   // base styles
   width: '100%',
@@ -66,8 +81,8 @@ export const Button = styled('button', {
     fontWeight: {
       light: {
         fontWeight: 500,
-      }
-    }
+      },
+    },
   },
   cursor: 'pointer',
   padding: '8px 12px',


### PR DESCRIPTION
## Why?

Disabled buttons did not show the not allowed cursor when hovered on.

## How?

- Added the 'not allowed' property to the button styles when disabled.

## Tickets?

- [Notion](https://www.notion.so/Keyboard-accessibility-Globally-117c41bca6d14cbfb30886296508db74#b94f3a1f8fa348c88e31695bfe108879)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/171964535-b821e6a3-6685-40e6-8653-6001fb9e1f67.mov
