### PR TITLE
fix: 🐛 remove cancel button from buy now modal

### DIFF
--- a/src/components/modals/buy-now-modal.tsx
+++ b/src/components/modals/buy-now-modal.tsx
@@ -194,21 +194,6 @@ export const BuyNowModal = ({
               ---------------------------------
             */}
               <Pending />
-              {/*
-              ---------------------------------
-              Pending Action Buttons
-              ---------------------------------
-            */}
-              <ModalButtonsList>
-                <ModalButtonWrapper fullWidth>
-                  <ActionButton
-                    type="secondary"
-                    onClick={handleModalClose}
-                  >
-                    {t('translation:modals.buttons.cancel')}
-                  </ActionButton>
-                </ModalButtonWrapper>
-              </ModalButtonsList>
             </Container>
           )}
           {/*


### PR DESCRIPTION
## Why?

Remove cancel button from buy now modal

## How?

- [x] remove cancel button from buy now modal

## Tickets?

- [Ticket 1](https://www.notion.so/Bugs-e7c06439e4a54367896696b84266c2ee#fe565121f2d049bf97adce676be43b82)
