### PR TITLE
fix: 🐛 plug dropdown going over modal overlay

### DIFF
--- a/src/components/modals/styles.ts
+++ b/src/components/modals/styles.ts
@@ -85,7 +85,7 @@ export const ModalOverlayContainer = styled(DialogPrimitive.Overlay, {
   backgroundColor: '$modalOverlay',
   position: 'fixed',
   inset: 0,
-  zIndex: 3,
+  zIndex: 5,
   '@media (prefers-reduced-motion: no-preference)': {
     animation: `${overlayShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
   },
@@ -101,7 +101,7 @@ export const ModalContent = styled(DialogPrimitive.Content, {
   left: '50%',
   transform: 'translate(-50%, -50%)',
   padding: 45,
-  zIndex: 4,
+  zIndex: 6,
   '@media (prefers-reduced-motion: no-preference)': {
     animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1)`,
   },


### PR DESCRIPTION
## Why?

The plug dropdown was going over the modal overlay.

## How?

- Increased the z-index value for modal content and modal overlay

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#28e118e0b2544d8db467bee9f0e98395)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/172179759-1cb13261-5e90-461a-bf75-d6215e2b7228.mov
