### PR TITLE
fix: 🐛 fix infinite loader skeleton for tables

### DIFF
--- a/src/components/tables/activity-table.tsx
+++ b/src/components/tables/activity-table.tsx
@@ -165,6 +165,8 @@ export const ActivityTable = () => {
           loaderDetails={{
             showItemDetails: true,
             showTypeDetails: true,
+            type: 'large',
+            infiniteLoader: true,
           }}
         />
       }

--- a/src/components/tables/my-offers-table.tsx
+++ b/src/components/tables/my-offers-table.tsx
@@ -312,6 +312,7 @@ export const MyOffersTable = ({ offersType }: MyOffersTableProps) => {
               loaderDetails={{
                 showItemDetails: true,
                 showTypeDetails: true,
+                infiniteLoader: true,
               }}
             />
           }

--- a/src/components/tables/styles.ts
+++ b/src/components/tables/styles.ts
@@ -186,10 +186,28 @@ export const ButtonWrapper = styled('div', {
 });
 
 export const InfiniteScrollWrapper = styled(InfiniteScroll as any, {
-  width: '100%',
+
+  table: {
+    width: 'inherit',
+
+    tr: {
+      td: {
+        padding: '25px 0px 25px 10px',
+
+        '&:first-child': {
+          paddingLeft: '80px',
+        },
+      },
+    },
+  },
+
+  '&:hover': {
+    background: '$tableRowHoverColor',
+  },
 });
 
 export const TableSkeletonsWrapper = styled('tr', {
+
   // variants
   variants: {
     type: {

--- a/src/components/tables/table-skeletons.tsx
+++ b/src/components/tables/table-skeletons.tsx
@@ -1,5 +1,5 @@
 import { SkeletonBox } from '../core/skeleton';
-import { TableSkeletonsWrapper, Flex } from './styles';
+import { TableSkeletonsWrapper, Flex, Container } from './styles';
 
 export type TableSkeletonProps = {
   loaderDetails: {
@@ -7,6 +7,7 @@ export type TableSkeletonProps = {
     showTypeDetails?: boolean;
     type?: any;
     hideColumns?: boolean;
+    infiniteLoader?: boolean;
   };
 };
 
@@ -55,19 +56,38 @@ const TableSkeletons = ({
     showTypeDetails = true,
     type = 'large',
     hideColumns,
+    infiniteLoader,
   },
-}: TableSkeletonProps) => (
-  <TableSkeletonsWrapper type={type} role="row">
-    {showItemDetails && <ItemDetail />}
-    {showTypeDetails && <TypeDetail />}
-    <TableStrings type={type} hideColumns={hideColumns} />
-    <TableStrings type={type} hideColumns={hideColumns} />
-    <TableStrings type={type} hideColumns={hideColumns} />
-    <TableStrings type={type} hideColumns={hideColumns} />
-    {hideColumns === false && (
+}: TableSkeletonProps) =>
+  infiniteLoader ? (
+    <Container>
+      <table>
+        <tbody>
+          <TableSkeletonsWrapper type={type} role="row">
+            {showItemDetails && <ItemDetail />}
+            {showTypeDetails && <TypeDetail />}
+            <TableStrings type={type} hideColumns={hideColumns} />
+            <TableStrings type={type} hideColumns={hideColumns} />
+            <TableStrings type={type} hideColumns={hideColumns} />
+            <TableStrings type={type} hideColumns={hideColumns} />
+            {hideColumns === false && (
+              <TableStrings type={type} hideColumns={hideColumns} />
+            )}
+          </TableSkeletonsWrapper>
+        </tbody>
+      </table>
+    </Container>
+  ) : (
+    <TableSkeletonsWrapper type={type} role="row">
+      {showItemDetails && <ItemDetail />}
+      {showTypeDetails && <TypeDetail />}
       <TableStrings type={type} hideColumns={hideColumns} />
-    )}
-  </TableSkeletonsWrapper>
-);
-
+      <TableStrings type={type} hideColumns={hideColumns} />
+      <TableStrings type={type} hideColumns={hideColumns} />
+      <TableStrings type={type} hideColumns={hideColumns} />
+      {hideColumns === false && (
+        <TableStrings type={type} hideColumns={hideColumns} />
+      )}
+    </TableSkeletonsWrapper>
+  );
 export default TableSkeletons;


### PR DESCRIPTION
## Why?

The infinite scroll table skeleton is not being rendered properly.

## How?

- Wrapped table skeleton with the `table` tag if it is being rendered by the infinite scroller.

## Tickets?

- [Notion](https://www.notion.so/New-desktop-feedback-31-05-22-259bc3b4bb204591bdc29c4f54145eec#48b1fabad84b4b7c94cfa5d10ae64969)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/172274627-dc735623-e837-48b1-8529-6ca37c57bc33.mov
