### PR TITLE
fix: 🐛 navigation history in tabs selection

### DIFF
--- a/src/components/tabs/collection-tabs.tsx
+++ b/src/components/tabs/collection-tabs.tsx
@@ -40,7 +40,7 @@ export const CollectionTabs = () => {
         <TabsTrigger
           value="items"
           status={itemsStatus}
-          onClick={() => navigate('/', { replace: true })}
+          onClick={() => navigate('/')}
         >
           <Icon icon="grid" paddingRight />
           {t('translation:tabs.items')}
@@ -48,7 +48,7 @@ export const CollectionTabs = () => {
         <TabsTrigger
           value="activity"
           status={activityStatus}
-          onClick={() => navigate('/activity', { replace: true })}
+          onClick={() => navigate('/activity')}
         >
           <Icon icon="activity" paddingRight />
           {t('translation:tabs.activity')}


### PR DESCRIPTION
## Why?

Fix navigation history in tabs selection

## How?

- [x] remove `replace: true` while navigating between tabs

## Demo?


https://user-images.githubusercontent.com/40259256/172311568-90efd524-2898-4b18-8a44-ffea28fe8604.mov


