### PR TITLE
fix: 🐛 on filters collapse, resizes list view

### DIFF
--- a/src/components/filters/filters.tsx
+++ b/src/components/filters/filters.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, DOMElement } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { triggerWindowResizeEvent } from '../../utils/window';
 import {
   useFilterStore,
   filterActions,
@@ -72,14 +73,14 @@ export const Filters = () => {
   }, [displayPriceApplyButton]);
 
   useEffect(() => {
-    console.log('[debug] collapsed', collapsed);
-
     // Triggering the resize event twice
     // is intentional, as required by list view
-    // virtualized list when
-    // the filter returns from collapsed
-    window.dispatchEvent(new Event('resize'));
-    window.dispatchEvent(new Event('resize'));
+    // virtualized list when the filter returns from collapsed
+    triggerWindowResizeEvent();
+    // The second resize call is only required when NOT collapsed
+    // this is when going from collapse to NOT collapsed
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    !collapsed && triggerWindowResizeEvent();
   }, [collapsed]);
 
   const filterExists = (filterName: string) =>
@@ -176,16 +177,16 @@ export const Filters = () => {
 
   return (
     <Container>
-      <CloseFilterContainer opened={!collapsed}>
+      <CloseFilterContainer opened={collapsed}>
         <IconActionButton
           handleClick={() => {
             dispatch(settingsActions.setFilterCollapsed(!collapsed));
           }}
         >
-          <CollapseIcon icon="arrow-left" rotate={!collapsed} />
+          <CollapseIcon icon="arrow-left" rotate={collapsed} />
         </IconActionButton>
       </CloseFilterContainer>
-      {collapsed && (
+      {!collapsed && (
         <FiltersContainer>
           <FilterHeader>
             <Heading>Filters</Heading>

--- a/src/store/features/settings/settings-slice.ts
+++ b/src/store/features/settings/settings-slice.ts
@@ -15,7 +15,7 @@ export interface SettingsState {
 }
 
 const initialState: SettingsState = {
-  collapsed: true,
+  collapsed: false,
   displayPriceApplyButton: false,
   showAlerts: false,
   assetsToWithdraw: [],

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,0 +1,2 @@
+export const triggerWindowResizeEvent = () =>
+  window.dispatchEvent(new Event('resize'));


### PR DESCRIPTION
## Why?

On filters collapse, the list view should be resized

## Demo?

https://user-images.githubusercontent.com/236752/172365324-f97b1f59-6019-4f43-a0a3-1169bf46ff5a.mp4


