### PR TITLE
refactor: 💡 added scrollbar to offers accordion

### DIFF
--- a/src/components/core/accordions/styles.ts
+++ b/src/components/core/accordions/styles.ts
@@ -272,7 +272,13 @@ export const AccordionTrigger = styled(Accordion.Trigger, {
 
 export const AccordionContent = styled(Accordion.Content, {
   color: '$mainTextColor',
-  overflow: 'hidden',
+  overflow: 'scroll',
+  msOverflowStyle: 'none',
+  scrollbarWidth: 'none',
+
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
 
   '&[data-state="open"]': {
     animation: `${slideDown} 700ms cubic-bezier(0.87, 0, 0.13, 1) forwards`,


### PR DESCRIPTION
## Why?

The content of the offers accordion were not scrollable.

## How?

- Added a scroll style to accordion content.

## Tickets?

- [Notion](https://www.notion.so/Desktop-7th-June-6413751bd3cf4570b8c842ffe138b73f#dc55e8252e9c423784e12459a2943de9)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/172618470-43aebdad-8d39-43f4-931b-543c1a9821a2.mov
