### PR TITLE
fix: 🐛 show NFT top offer when user not connected to plug

### DIFF
--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -44,6 +44,7 @@ import {
   parseE8SAmountToWICP,
   formatPriceValue,
 } from '../../../utils/formatters';
+import { isTokenId } from '../../..//utils/nfts';
 
 export type OfferAccordionProps = {
   lastSalePrice?: string;
@@ -209,11 +210,11 @@ export const OfferAccordion = ({
 
   useEffect(() => {
     // TODO: handle the error gracefully when there is no id
-    if (!id) return;
+    if (!isTokenId(id)) return;
 
     dispatch(
       marketplaceActions.getTokenOffers({
-        ownerTokenIdentifiers: [BigInt(id)],
+        ownerTokenIdentifiers: [BigInt(id as string)],
 
         onSuccess: () => {
           setLoadingOffers(false);


### PR DESCRIPTION
## Why?

We should show the “Top Offer” when we have that in the activity table irrespective of whether being connected to plug or not

## How?

- [x] remove principal Id check logic before fetching token offers

## Tickets?

- [Ticket](https://www.notion.so/We-should-show-the-Top-Offer-when-we-have-that-in-the-activity-table-irrespective-of-whether-being-47c3f5be2ba94a3c919f1c9239217d7a)

## Demo?

<img width="1430" alt="Screenshot 2022-06-09 at 8 53 50 AM" src="https://user-images.githubusercontent.com/40259256/172758078-8625dcb9-3b86-4231-83f6-e7f529f9ebca.png">

