### PR TITLE
fix: 🐛 update withdraw assets link label name

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -290,6 +290,6 @@
   },
   "alerts": {
     "transactionsMessage": "You have unfinished or failed transactions,",
-    "retryMessage": "click here to retry."
+    "retryMessage": "click here to withdraw."
   }
 }


### PR DESCRIPTION
## Why?

Update withdraw assets link label name

## How?

- [x] Update withdraw assets link label name from `click here to retry` to `click here to withdraw`
