### PR TITLE
perf: ⚡image cache, remove listener after being invoked once

### DIFF
--- a/src/components/image-preload/image-preload.tsx
+++ b/src/components/image-preload/image-preload.tsx
@@ -18,8 +18,6 @@ export const ImagePreload = React.memo(
   forwardRef<HTMLImageElement, ImagePreloadProps>(
     ({ src, ...props }, ref) => {
       const [loaded, setLoaded] = useState(false);
-      const image = ImageCache.get(src);
-
       const onLoad = () => setLoaded(true);
 
       useEffect(() => {
@@ -34,7 +32,7 @@ export const ImagePreload = React.memo(
         return () => {
           ImageCache.removeListener(src);
         };
-      }, [src, image]);
+      }, [src]);
 
       if (!loaded) {
         return (

--- a/src/utils/image-cache.ts
+++ b/src/utils/image-cache.ts
@@ -58,9 +58,7 @@ export class ImageCache {
     });
   }
 
-  static get(url?: string): HTMLImageElement | undefined {
-    if (!url) return;
-
+  static get(url: string): HTMLImageElement | undefined {
     return this.cache[url];
   }
 


### PR DESCRIPTION
## Why?

The event listener for load should be removed after being invoked to prevent memory leaks on unmounted components, etc.

As reported and 🐛 which should also fix

![image](https://user-images.githubusercontent.com/236752/173116554-cfadc8d7-0850-4976-916d-84ee1d06d5f7.png)

## Demo?

https://user-images.githubusercontent.com/236752/173117017-273b54c2-542d-49d2-8f2d-9434244e3fe5.mp4


