### PR TITLE
fix: 🐛 horizontal scroll on filters bar

### DIFF
--- a/src/components/filters/styles.ts
+++ b/src/components/filters/styles.ts
@@ -32,7 +32,8 @@ export const FiltersContainer = styled('div', {
   borderTop: '1px solid $borderColor',
   position: 'sticky',
   top: '0',
-  overflow: 'scroll',
+  overflowY: 'scroll',
+  overflowX: 'hidden',
   msOverflowStyle: 'none',
   scrollbarWidth: 'none',
 


### PR DESCRIPTION
## Why?

The filter tab was scrollable horizontally.

## How?

- Added a css property to prevent horizontal scroll.

## Tickets?

- [Notion](https://www.notion.so/Desktop-9th-June-fbeee89d43d24512a7acfb33d3e5e0cb#368df5182cca4270aca81d4ef7eefe20)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/173065850-2c1bf8ad-d5a4-47d3-8aa3-9bf5297293b5.mov
