### PR TITLE
refactor: 💡 show price range filters on status toggle

### DIFF
--- a/src/components/filters/filters.tsx
+++ b/src/components/filters/filters.tsx
@@ -146,6 +146,7 @@ export const Filters = () => {
 
       return;
     }
+
     if (priceFilterValue.max === '') {
       dispatch(
         notificationActions.setErrorMessage(
@@ -155,6 +156,7 @@ export const Filters = () => {
 
       return;
     }
+
     if (priceFilterValue.min === '' && priceFilterValue.max !== '') {
       setPriceFilterValue((prevState) => ({
         ...prevState,
@@ -167,6 +169,7 @@ export const Filters = () => {
 
       return;
     }
+
     if (priceFilterValue.min !== '' && priceFilterValue.max !== '') {
       applyFilter(
         `${t('translation:filters.priceRange')}`,
@@ -324,41 +327,43 @@ export const Filters = () => {
                   </FilterButtonWrapper>
                 </Flex>
               </FilterGroup>
-              <FilterGroup>
-                <Subheadings>Price Range</Subheadings>
-                <Flex justify="spaceBetween">
-                  <FilterInput
-                    placeholder={t(
-                      'translation:inputField.placeholder.priceMin',
-                    )}
-                    inputValue={priceFilterValue.min}
-                    setValue={(value) => {
-                      applyPriceFilter(value, false);
-                    }}
-                  />
-                  <Subtext margin="rightAndLeft" color="secondary">
-                    to
-                  </Subtext>
-                  <FilterInput
-                    placeholder={t(
-                      'translation:inputField.placeholder.priceMax',
-                    )}
-                    inputValue={priceFilterValue.max}
-                    setValue={(value) => {
-                      applyPriceFilter(value, true);
-                    }}
-                  />
-                </Flex>
-                <br />
-                {displayPriceApplyButton && (
-                  <ActionButton
-                    type="secondary"
-                    onClick={handlePriceFilter}
-                  >
-                    {t('translation:buttons.action.apply')}
-                  </ActionButton>
-                )}
-              </FilterGroup>
+              {Boolean(status.length) && (
+                <FilterGroup>
+                  <Subheadings>Price Range</Subheadings>
+                  <Flex justify="spaceBetween">
+                    <FilterInput
+                      placeholder={t(
+                        'translation:inputField.placeholder.priceMin',
+                      )}
+                      inputValue={priceFilterValue.min}
+                      setValue={(value) => {
+                        applyPriceFilter(value, false);
+                      }}
+                    />
+                    <Subtext margin="rightAndLeft" color="secondary">
+                      to
+                    </Subtext>
+                    <FilterInput
+                      placeholder={t(
+                        'translation:inputField.placeholder.priceMax',
+                      )}
+                      inputValue={priceFilterValue.max}
+                      setValue={(value) => {
+                        applyPriceFilter(value, true);
+                      }}
+                    />
+                  </Flex>
+                  <br />
+                  {displayPriceApplyButton && (
+                    <ActionButton
+                      type="secondary"
+                      onClick={handlePriceFilter}
+                    >
+                      {t('translation:buttons.action.apply')}
+                    </ActionButton>
+                  )}
+                </FilterGroup>
+              )}
             </FilterSection>
             <Heading>Traits</Heading>
             <FilterSection>


### PR DESCRIPTION
## Why?

Only show price range filters when a status is applied.

## How?

- Hide price range filters if not status is selected.

## Tickets?

- [Notion](https://www.notion.so/Range-Filter-not-working-correctly-When-we-put-0-as-the-minimum-and-any-number-as-maximum-it-does-8ad2ba3cae0243108394e72b44ac7606)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/173097325-a5e46fc4-4e0b-41d8-a75d-c40b8b5ece0b.mov
