### PR TITLE
chore: 🤖 remove cap from Plug whitelist

### DIFF
--- a/src/components/plug/plug.tsx
+++ b/src/components/plug/plug.tsx
@@ -27,7 +27,6 @@ const {
   nftCollectionId,
   marketplaceCanisterId,
   wICPCanisterId,
-  capRouterId,
   host,
 } = config;
 
@@ -35,7 +34,6 @@ const whitelist = [
   nftCollectionId,
   marketplaceCanisterId,
   wICPCanisterId,
-  capRouterId,
 ];
 
 export const Plug = () => {


### PR DESCRIPTION
## Why?

CAP should be remove from the Plug whitelist, as we do not trigger events in Plug.