### PR TITLE
fix: 🐛 failed to retrieve bucket id (revert Cap removal Plug whitelist)

### DIFF
--- a/src/components/plug/plug.tsx
+++ b/src/components/plug/plug.tsx
@@ -27,6 +27,7 @@ const {
   nftCollectionId,
   marketplaceCanisterId,
   wICPCanisterId,
+  capRouterId,
   host,
 } = config;
 
@@ -34,6 +35,7 @@ const whitelist = [
   nftCollectionId,
   marketplaceCanisterId,
   wICPCanisterId,
+  capRouterId,
 ];
 
 export const Plug = () => {


### PR DESCRIPTION
## Why?

<img width="590" alt="Screenshot 2022-06-10 at 18 38 46" src="https://user-images.githubusercontent.com/236752/173121714-0836c0cc-ba81-4672-af34-48d46a27ba48.png">

## Demo?

<img width="1626" alt="Screenshot 2022-06-10 at 18 41 36" src="https://user-images.githubusercontent.com/236752/173121772-6f54e271-9ad1-4f0e-ba01-4534650e6c83.png">
