### PR TITLE
feat: 🎸 cancel pending filter requests on new request made

### DIFF
--- a/src/store/features/nfts/async-thunks/get-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-nfts.ts
@@ -14,9 +14,19 @@ export type GetNFTsProps = NSKyasshuUrl.GetNFTsQueryParams & {
   payload?: any;
 };
 
+let cancelToken: any;
+
 export const getNFTs = createAsyncThunk<void, GetNFTsProps>(
   'nfts/getNFTs',
   async ({ payload, sort, order, page, count }, { dispatch }) => {
+    //Check if there are any previous pending requests
+    if (typeof cancelToken != typeof undefined) {
+      cancelToken.cancel('Operation canceled due to new request.');
+    }
+
+    //Save the cancel token for the current request
+    cancelToken = axios.CancelToken.source();
+
     // set loading NFTS state to true
     if (page === 0) {
       dispatch(nftsActions.setIsNFTSLoading(true));
@@ -30,6 +40,7 @@ export const getNFTs = createAsyncThunk<void, GetNFTsProps>(
       const response = await axios.post(
         KyasshuUrl.getNFTs({ sort, order, page, count }),
         payload,
+        { cancelToken: cancelToken.token }, //Pass the cancel token to the current request
       );
 
       if (response.status !== 200) {


### PR DESCRIPTION
## Why?

Need to call abort on previous filter request when applying a new one

## How?

- [x] use `axios cancelToken`
- [ ] to be defined 

## Tickets?

- [Ticket](https://www.notion.so/Jelly-Feedback-a8e4bbd706bf439facd89bbd09858760?p=c2aece765fee4cb4a6a4b94d6d6e02bc)

## Demo?

<img width="1429" alt="Screenshot 2022-06-13 at 5 00 40 PM" src="https://user-images.githubusercontent.com/40259256/173344614-9bc55b87-11c6-4d0f-97dd-1e31ec4c28d5.png">

