### PR TITLE
chore: 🤖 remove cap from plug whitelist

### DIFF
--- a/src/components/plug/plug.tsx
+++ b/src/components/plug/plug.tsx
@@ -27,7 +27,6 @@ const {
   nftCollectionId,
   marketplaceCanisterId,
   wICPCanisterId,
-  capRouterId,
   host,
 } = config;
 
@@ -35,7 +34,6 @@ const whitelist = [
   nftCollectionId,
   marketplaceCanisterId,
   wICPCanisterId,
-  capRouterId,
 ];
 
 export const Plug = () => {


### PR DESCRIPTION
## Why?

Cap canister id does not need to be placed in the Plug Whitelist, as the call is now done via none Plug actor.

