### PR TITLE
chore: 🤖 show event type on detail view activity table 

### DIFF
--- a/src/components/core/table-cells/type-details-cell.tsx
+++ b/src/components/core/table-cells/type-details-cell.tsx
@@ -24,7 +24,7 @@ export const TypeDetailsCell = ({
 }: TypeDetailsCellProps) => {
   const { t } = useTranslation();
   return (
-    <TypeDetails>
+    <TypeDetails data-event-type={type}>
       {type && Object.keys(EventIcon).includes(type) && (
         <Icon icon={EventIcon[type]} paddingRight />
       )}


### PR DESCRIPTION
## Why?

For debugging, should show event type on detail view activity table .

## Demo?

<img width="1275" alt="Screenshot 2022-06-17 at 16 11 51" src="https://user-images.githubusercontent.com/236752/174326624-5269984c-d336-4529-b1da-cc8473565236.png">
