### PR TITLE
perf: ⚡fix calling same API multiple times when filters applied

### DIFF
--- a/src/store/features/nfts/async-thunks/get-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-nfts.ts
@@ -23,9 +23,7 @@ export const getNFTs = createAsyncThunk<void, GetNFTsProps>(
     { dispatch },
   ) => {
     // set loading NFTS state to true
-    if (page === 0) {
-      dispatch(nftsActions.setIsNFTSLoading(true));
-    }
+    dispatch(nftsActions.setIsNFTSLoading(true));
 
     if (!isEmptyObject(payload)) {
       dispatch(nftsActions.setCollectionDataLoading());


### PR DESCRIPTION
## Why?

Fix calling same API multiple times when filters applied

## How?

- [x] Enable loading state for all the pages when API call made
