### PR TITLE
chore: 🤖 handle more error messages from backend

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,6 +1,8 @@
 type Err = Record<string, any>;
 
 const toErrorMessage = (errorKey: string) => {
+  console.warn(errorKey);
+
   // TODO: Error messages should use intl translate
   switch (errorKey) {
     case 'InsufficientFungibleBalance':
@@ -8,6 +10,18 @@ const toErrorMessage = (errorKey: string) => {
       return 'Oops! Insufficient fungible balance';
     case 'Unauthorized':
       return 'Oops! Marketplace is not authorized to perform the transaction';
+    case 'InvalidOperator':
+    case 'InvalidOwner':
+      return "Oops! Can't be purchased at this time, possibly because token was transferred outside Jelly marketplace to a new wallet";
+    case 'NoDeposit':
+      return 'Oops! Missing deposit';
+    case 'InvalidOffer':
+    case 'InvalidOfferStatus':
+      return 'Oops! The offer is not valid';
+    case 'NonExistentCollection':
+      return 'Oops! Unknown collection';
+    case 'InvalidListing':
+      return 'Oops! The listing is invalid or was not found at this time';
     default:
       return 'Oops! Unknown error';
   }


### PR DESCRIPTION
## Why?

There are missing error messages that should be displayed to the end user.

## Demo?

<img width="1035" alt="Screenshot 2022-06-23 at 17 26 57" src="https://user-images.githubusercontent.com/236752/175348501-01661e7c-eea4-4d6e-8dec-abc8877e6654.png">

