### PR TITLE
refactor: 💡 show table header on offer table empty state

### DIFF
--- a/src/components/tables/nft-offers-table.tsx
+++ b/src/components/tables/nft-offers-table.tsx
@@ -140,9 +140,7 @@ export const NFTOffersTable = ({
       },
       {
         Header: t('translation:tables.titles.from'),
-        accessor: ({
-          fromDetails,
-        }: OffersTableItem) => {
+        accessor: ({ fromDetails }: OffersTableItem) => {
           const isOwner = isNFTOwner({
             isConnected,
             owner: fromDetails.address,
@@ -202,29 +200,21 @@ export const NFTOffersTable = ({
   const { loading, loadedOffers } = tableDetails;
 
   return (
-    <>
-      {(loading || (!loading && loadedOffers.length > 0)) && (
-        <Container>
-          <TableLayout
-            columns={columns}
-            data={loadedOffers}
-            tableType="offers"
-            columnsToHide={columnsToHide}
-            loading={loading}
-            loaderDetails={{
-              showItemDetails: false,
-              showTypeDetails: false,
-              type: 'small',
-              hideColumns,
-            }}
-          />
-        </Container>
-      )}
-      {!loading && loadedOffers.length === 0 && (
-        <EmptyStateMessage type="smallTable">
-          {t('translation:emptyStates.noOffersYet')}
-        </EmptyStateMessage>
-      )}
-    </>
+    <Container>
+      <TableLayout
+        columns={columns}
+        data={loadedOffers}
+        tableType="offers"
+        columnsToHide={columnsToHide}
+        loading={loading}
+        loaderDetails={{
+          showItemDetails: false,
+          showTypeDetails: false,
+          type: 'small',
+          hideColumns,
+        }}
+        emptyMessage={t('translation:emptyStates.noOffersYet')}
+      />
+    </Container>
   );
 };


### PR DESCRIPTION
## Why?

Show table header under offers empty state on the nft offers accordion.

## How?

- Passed in `emptyMessage` prop to the `TableLayout` component
- Removed conditional statement rendering the error message outside the `TableLayout` component

## Tickets?

- [Notion](https://www.notion.so/Nice-to-have-We-dont-show-any-Fields-under-Offers-section-this-is-on-a-specific-NFT-s-page-if-t-66fe3167f04d4fe7b1be53763340f2dc)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

<img width="1440" alt="Screenshot 2022-06-27 at 12 29 43" src="https://user-images.githubusercontent.com/51888121/175932654-a1c1469a-de1e-4e89-9a66-3db086dde36c.png">
