### PR TITLE
refactor: 💡show insufficient balance while making an offer

### DIFF
--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -111,6 +111,8 @@ export const MakeOfferModal = ({
     setModalOpened(false);
   };
 
+  // TODO: add step to handle insufficient balance in UI
+
   return (
     <DialogPrimitive.Root
       open={modalOpened}


### PR DESCRIPTION
## Why?

Modal that shows they don’t have enough funds to make offer

## How?

- [ ] verify balance and open insufficient balance step when balance is insufficient while user is trying to make an offer

## Tickets?

- [Notion ticket](https://www.notion.so/Post-Release-Feedback-4da676e97710421c8a19781d09f6dc93#0a00f2a34bc644659be75805be4f5d56)


## Demo?

++ to be defined
