### PR TITLE
fix: 🐛 type conversion error browserlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
## Why?

Type conversion error; https://forum.dfinity.org/t/cannot-convert-a-bigint-value-to-a-number/5470/12
