### PR TITLE
fix: 🐛 start script cap router name

### DIFF
--- a/.scripts/start.sh
+++ b/.scripts/start.sh
@@ -10,7 +10,7 @@ if [[ $env == "development" ]]; then
   MKP_ID=$(cd nft-marketplace && dfx canister id marketplace)
   CROWNS_ID=$(cd nft-marketplace/crowns && dfx canister id crowns)
   WICP_ID=$(cd nft-marketplace/wicp && dfx canister id wicp) 
-  CAP_ID=$(cd nft-marketplace/cap && dfx canister id ic-history-router)
+  CAP_ID=$(cd nft-marketplace/cap && dfx canister id cap-router)
 
   printf "🤖 Marketplace id (%s), CrownsId (%s), WicpId (%s), CapId (%s)\n" "$MKP_ID" "$CROWNS_ID" "$WICP_ID" "$CAP_ID"
 


### PR DESCRIPTION
## Why?

ic history router is now cap router, as such the start script has to change

## Demo?

Optionally, provide any screenshot, gif or small video.
