### PR TITLE
chore: 🤖 kyasshu allowed canister ids env vars

### DIFF
--- a/.scripts/kyasshu/start.sh
+++ b/.scripts/kyasshu/start.sh
@@ -9,6 +9,7 @@ if [[ -z $host || "$host" == "local" ]]; then
   export MARKETPLACE_CANISTER_ID=$(cd nft-marketplace && dfx canister id marketplace)
   export NFT_CANISTER_ID=$(cd nft-marketplace/crowns && dfx canister id crowns)
   export NFT_CANISTER_STANDARD='DIP721v2'
+  export MARKETPLACE_ALLOWED_CANISTERS="{ \"$NFT_CANISTER_ID\": \"DIP721v2\" }"
 elif [[ "$host" != 'mainnet' ]]; then
   printf "usage: yarn kyasshu:start [service cluster: local | mainnet]\n"
   exit 1
@@ -23,5 +24,4 @@ printf "🤖 Starting kyasshu with the $host services...\n\n"
 
 cd kyasshu
 
-# The Crowns canister id is a required environment var
-MARKETPLACE_ALLOWED_CANISTERS="{ \"$NFT_CANISTER_ID\": \"DIP721v2\" }" yarn dev
+yarn dev

--- a/.scripts/kyasshu/start.sh
+++ b/.scripts/kyasshu/start.sh
@@ -22,4 +22,6 @@ printf "🤖 Starting kyasshu with the $host services...\n\n"
 [[ ! -z $NFT_CANISTER_STANDARD ]] && printf "  Using NFT_CANISTER_STANDARD: $NFT_CANISTER_STANDARD\n\n"
 
 cd kyasshu
-yarn dev
+
+# The Crowns canister id is a required environment var
+MARKETPLACE_ALLOWED_CANISTERS="{ \"$NFT_CANISTER_ID\": \"DIP721v2\" }" yarn dev


### PR DESCRIPTION
## Why?

The Kyasshu start script should include the allowed canister ids as a json string.
