### PR TITLE
refactor: 💡update insufficient balance text while making an offer

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -215,7 +215,7 @@
       "editOffer": "Edit Offer",
       "withdrawAssets": "Withdraw Assets",
       "withdrawalSuccess": "Withdrawal Success",
-      "notEnoughFunds": "Not enough funds"
+      "notEnoughFunds": "Insufficient Funds"
     },
     "description": {
       "makeListing": "Enter the sale price you want for your NFT.",
@@ -232,7 +232,7 @@
       "offerAccepted": "Congrats, you successfully accepted an offer.",
       "withdrawAssets": "The following fungible balances remain in the canister due to an error completing a transaction. Review the assets and click retry to receive them.",
       "notEnoughFundsToPurchase": "Transfer funds to your wallet to continue with the purchase of this NFT. If you have another asset you would like to swap for WICP you can use Sonic.",
-      "notEnoughFundsToMakeOffer": "Transfer funds to your wallet to continue make offer over this NFT. If you have another asset you would like to swap for WICP you can use Sonic."
+      "notEnoughFundsToMakeOffer": "Your wallet does not have the minimum required funds to make this offer. Please acquire the funds and try again."
     },
     "labels": {
       "protocolFee": "Protocol fee",


### PR DESCRIPTION
## Why?

Update insufficient balance text while making an offer

## How?

- [x] update `notEnoughFundsToMakeOffer` value in locale to update insufficient balance description

## Tickets?

- [Notion](https://discord.com/channels/837010835423494144/911179346604089374/998646549439590510)

## Demo?

<img width="1436" alt="Screenshot 2022-07-19 at 1 34 05 PM" src="https://user-images.githubusercontent.com/40259256/179701070-ee1abb41-0d59-4f9b-86f8-3727530874a3.png">

