### PR TITLE
fix: 🐛 show last sale details in NFT card when there is no offer, but sold

### DIFF
--- a/src/components/core/cards/nft-card/nft-card.tsx
+++ b/src/components/core/cards/nft-card/nft-card.tsx
@@ -135,7 +135,7 @@ const LastActionTakenDetails = ({
   if (data?.lastActionTaken === NFTActionStatuses.Sold) {
     return (
       <ActionDetails>
-        {data?.lastOffer && (
+        {data?.lastSale && (
           <>
             <ActionText>
               {t('translation:nftCard.lastSale')}


### PR DESCRIPTION
## Why?

Show last sale details in NFT card when there is no offer, but sold

## How?

- [x] Update last sale details in NFT Card component

## Demo?

Issue:

<img width="1430" alt="Screenshot 2022-07-19 at 4 18 07 PM" src="https://user-images.githubusercontent.com/40259256/179733398-7010298b-8637-4af8-a3ed-b89f5390f68a.png">

Fix:

<img width="1438" alt="Screenshot 2022-07-19 at 4 18 19 PM" src="https://user-images.githubusercontent.com/40259256/179733472-9a7cc359-92b9-4401-a8aa-baf6d651a3b9.png">

