### PR TITLE
fix: 🐛 redirect to home page with my nfts filter applied from dropdown

### DIFF
--- a/src/components/plug/plug-button.tsx
+++ b/src/components/plug/plug-button.tsx
@@ -96,6 +96,7 @@ export const PlugButton = ({
     );
 
   const setMyNfts = () => {
+    navigate('/');
     dispatch(filterActions.setMyNfts(true));
     if (filterExists(t('translation:buttons.action.myNfts'))) return;
     dispatch(


### PR DESCRIPTION
## Why?

Redirect to home page with my nfts filter applied from dropdown

## How?

- [x] use navigate to redirect users to homepage with `My NFTS` filter applied from dropdown

## Tickets?

- [Notion](https://discord.com/channels/837010835423494144/911179346604089374/996957913669185626)

## Demo?


https://user-images.githubusercontent.com/40259256/179738636-82734297-e9ff-4aca-bb6a-8b28027af4eb.mov


