### PR TITLE
chore: 🤖  kyasshu token endpoint update

### DIFF
--- a/src/integrations/kyasshu/kyasshu-urls.ts
+++ b/src/integrations/kyasshu/kyasshu-urls.ts
@@ -38,7 +38,7 @@ export class KyasshuUrl {
   static getTokenTransactions({
     tokenId,
   }: NSKyasshuUrl.GetTokenTransactions): string {
-    return `${config.kyasshuMarketplaceAPI}/cap/token/txns/${config.marketplaceCanisterId}/${tokenId}`;
+    return `${config.kyasshuMarketplaceAPI}/cap/token/txns/${config.nftCollectionId}/${tokenId}`;
   }
 
   static getSearchResults({


### PR DESCRIPTION
## Why?

Should use the correct endpoint, when prod kyasshu  is used.

⚠️ Requires Kyasshu prod to be used, at the moment we're still in kyasshu-dev

## Demo?

```
curl -X GET https://kyasshu.fleek.co/cap/token/txns/vlhm2-4iaaa-aaaam-qaatq-cai/9750
```
