### PR TITLE
fix: 🐛 token identifier for activity table

### DIFF
--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -279,6 +279,12 @@ export const parseTokenTransactions = ({
       }
     }
 
+    console.log('[debug] details: ', details);
+    console.log(
+      '[debug] curr.event.operation: ',
+      curr.event.operation,
+    );
+
     acc.push({
       item: {
         name: `CAP Crowns #${details.token_id.U64}`,

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -279,6 +279,18 @@ export const parseTokenTransactions = ({
       }
     }
 
+    if (isMint) {
+      const buyerPrincipal = parseTablePrincipal(
+        details.to?.Principal._arr,
+      );
+      if (buyerPrincipal) {
+        buyer = {
+          raw: buyerPrincipal.toString(),
+          formatted: formatAddress(buyerPrincipal.toString()),
+        };
+      }
+    }
+
     acc.push({
       item: {
         name: `CAP Crowns #${details.token_id.U64}`,

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -279,14 +279,12 @@ export const parseTokenTransactions = ({
       }
     }
 
-    if (isMint) {
-      const buyerPrincipal = parseTablePrincipal(
-        details.to?.Principal._arr,
-      );
-      if (buyerPrincipal) {
+    if (buyerPrincipalAs) {
+      const principal = parseTablePrincipal(buyerPrincipalAs);
+      if (principal) {
         buyer = {
-          raw: buyerPrincipal.toString(),
-          formatted: formatAddress(buyerPrincipal.toString()),
+          raw: principal.toString(),
+          formatted: formatAddress(principal.toString()),
         };
       }
     }

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -32,6 +32,9 @@ export type GetAllListingsDataParsed = {
 
 export type GetAllListingsDataParsedObj = Record<number, Listing>;
 
+export const parseTokenId = (val: String) =>
+  parseInt(val.replaceAll('_', ''), 10);
+
 export const parseAllListingResponse = (
   data: GetAllListingsDataResponse,
 ) => {
@@ -279,19 +282,14 @@ export const parseTokenTransactions = ({
       }
     }
 
-    if (buyerPrincipalAs) {
-      const principal = parseTablePrincipal(buyerPrincipalAs);
-      if (principal) {
-        buyer = {
-          raw: principal.toString(),
-          formatted: formatAddress(principal.toString()),
-        };
-      }
-    }
+    const tokenIdFieldAs =
+      details?.token_identifier ?? details?.token_id;
+    const parsedTokenId =
+      tokenIdFieldAs?.U64 ?? parseTokenId(tokenIdFieldAs?.Text);
 
     acc.push({
       item: {
-        name: `CAP Crowns #${details.token_id.U64}`,
+        name: `CAP Crowns #${parsedTokenId}`,
       },
       type: getOperationType(curr.event.operation),
       price:

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -279,12 +279,6 @@ export const parseTokenTransactions = ({
       }
     }
 
-    console.log('[debug] details: ', details);
-    console.log(
-      '[debug] curr.event.operation: ',
-      curr.event.operation,
-    );
-
     acc.push({
       item: {
         name: `CAP Crowns #${details.token_id.U64}`,


### PR DESCRIPTION
## Why?

The token identifier and value have to be parsed to take into account U64 and text containing "_" special underscore character.

## Demo?

<img width="1405" alt="Screenshot 2022-07-21 at 16 38 09" src="https://user-images.githubusercontent.com/236752/180254800-07199015-165b-4ae5-a5ee-d40f97aae57b.png">

