### PR TITLE
feat: 🎸 Handle page not found UI for unknown Collection or NFT

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import NFTView from './views/NFTView';
 import OfferView from './views/OffersView';
 import UserActivityView from './views/UserActivityView';
 import LandingPageView from './views/LandingPageView';
+import PageNotFound from './views/PageNotFoundView';
 import { useTheme } from './hooks/use-theme';
 import { portalZIndexGlobals } from './utils/styles';
 import { ThemeRootElement } from './constants/common';
@@ -36,6 +37,8 @@ const App = () => {
             path="/activity/:id"
             element={<UserActivityView />}
           />
+          {/* 👇️ only match this when no other routes match */}
+          <Route path="*" element={<PageNotFound />} />
         </Routes>
       </BrowserRouter>
       <ToastHandler />

--- a/src/constants/response-status.ts
+++ b/src/constants/response-status.ts
@@ -1,3 +1,4 @@
 export enum ResponseStatus {
   Canceled = 'canceled',
+  UnsupportedCollection = 'Unsupported collection',
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -297,7 +297,10 @@
     "noNFTId": "No NFT found with that ID",
     "noOffersYet": "No offers yet",
     "noOffersMade": "No offers made",
-    "nftActivity": "No activity found"
+    "nftActivity": "No activity found",
+    "notFoundTitle": "404",
+    "notFoundDescription": "We can't find the page that you're looking for",
+    "homeButton": "Take me home"
   },
   "errorMessages": {
     "priceEmptyField": "You need to fill in both values",

--- a/src/store/features/filters/async-thunks/get-filter-traits.ts
+++ b/src/store/features/filters/async-thunks/get-filter-traits.ts
@@ -7,9 +7,11 @@ import {
 import { FilterConstants } from '../../../../constants';
 import { filterActions, FilterTraitsList } from '..';
 import { notificationActions } from '../../notifications';
+import { settingsActions } from '../../settings';
 import { AppLog } from '../../../../utils/log';
 import { NFTMetadata } from '../../../../declarations/legacy';
 import { parseTraits } from '../../../../utils/traits';
+import { isUnsupportedPage } from '../../../../utils/error';
 
 export type GetFilterTraitsProps =
   NSKyasshuUrl.GetFilterTraitsQueryParams;
@@ -91,8 +93,15 @@ export const getFilterTraits = createAsyncThunk<
       dispatch(filterActions.getAllFilters(responseData));
       dispatch(filterActions.setIsFilterTraitsLoading(false));
       dispatch(filterActions.setIsAlreadyFetched(true));
-    } catch (error) {
+    } catch (error: any) {
       AppLog.error(error);
+
+      if (isUnsupportedPage(error?.response)) {
+        dispatch(settingsActions.setPageNotFoundStatus(true));
+
+        return;
+      }
+
       dispatch(
         notificationActions.setErrorMessage(
           'Oops! Unable to fetch traits',

--- a/src/store/features/marketplace/async-thunks/get-token-listing.ts
+++ b/src/store/features/marketplace/async-thunks/get-token-listing.ts
@@ -2,8 +2,6 @@ import { Principal } from '@dfinity/principal';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { actorInstanceHandler } from '../../../../integrations/actor';
 import { marketplaceSlice } from '../marketplace-slice';
-import { notificationActions } from '../../notifications';
-import config from '../../../../config/env';
 import { AppLog } from '../../../../utils/log';
 
 export const getTokenListing = createAsyncThunk<any | undefined, any>(
@@ -53,11 +51,6 @@ export const getTokenListing = createAsyncThunk<any | undefined, any>(
       };
     } catch (err) {
       AppLog.error(err);
-      thunkAPI.dispatch(
-        notificationActions.setErrorMessage(
-          `Oops! Failed to get token listing for id ${tokenId}`,
-        ),
-      );
       if (typeof onFailure === 'function') {
         onFailure(err);
       }

--- a/src/store/features/nfts/async-thunks/get-collection-data.ts
+++ b/src/store/features/nfts/async-thunks/get-collection-data.ts
@@ -6,8 +6,10 @@ import {
   NSKyasshuUrl,
 } from '../../../../integrations/kyasshu';
 import { notificationActions } from '../../notifications';
+import { settingsActions } from '../../settings';
 import { AppLog } from '../../../../utils/log';
 import { marketplaceActions } from '../../marketplace/marketplace-slice';
+import { isUnsupportedPage } from '../../../../utils/error';
 
 export const getCollectionData = createAsyncThunk<
   void,
@@ -65,8 +67,15 @@ export const getCollectionData = createAsyncThunk<
       );
 
       dispatch(nftsActions.setCollectionData(actionPayload));
-    } catch (error) {
+    } catch (error: any) {
       AppLog.error(error);
+
+      if (isUnsupportedPage(error?.response)) {
+        dispatch(settingsActions.setPageNotFoundStatus(true));
+
+        return;
+      }
+
       dispatch(
         notificationActions.setErrorMessage(
           'Oops! Unable to fetch collection data',

--- a/src/store/features/nfts/async-thunks/get-nft-details.ts
+++ b/src/store/features/nfts/async-thunks/get-nft-details.ts
@@ -6,7 +6,9 @@ import {
   NSKyasshuUrl,
 } from '../../../../integrations/kyasshu';
 import { notificationActions } from '../../notifications';
+import { settingsActions } from '../../settings';
 import { AppLog } from '../../../../utils/log';
+import { isUnsupportedPage } from '../../../../utils/error';
 
 export type GetNFTDetailsProps =
   NSKyasshuUrl.GetNFTDetailsQueryParams;
@@ -63,8 +65,15 @@ export const getNFTDetails = createAsyncThunk<
 
       // update store with loaded NFT details
       dispatch(nftsActions.setLoadedNFTDetails(nftDetails));
-    } catch (error) {
+    } catch (error: any) {
       AppLog.error(error);
+
+      if (isUnsupportedPage(error?.response)) {
+        dispatch(settingsActions.setPageNotFoundStatus(true));
+
+        return;
+      }
+
       dispatch(
         notificationActions.setErrorMessage(
           'Oops! Unable to fetch NFT details',

--- a/src/store/features/nfts/async-thunks/get-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-nfts.ts
@@ -6,11 +6,13 @@ import {
   NSKyasshuUrl,
 } from '../../../../integrations/kyasshu';
 import { notificationActions } from '../../notifications';
+import { settingsActions } from '../../settings';
 import { AppLog } from '../../../../utils/log';
 import { findLastAction } from '../../../../utils/nfts';
 import { isEmptyObject } from '../../../../utils/common';
 import { ResponseStatus } from '../../../../constants/response-status';
 import { SortOptions } from '../../../../constants/sort-options';
+import { isUnsupportedPage } from '../../../../utils/error';
 
 export type GetNFTsProps = NSKyasshuUrl.GetNFTsQueryParams & {
   payload?: any;
@@ -142,6 +144,12 @@ export const getNFTs = createAsyncThunk<void, GetNFTsProps>(
       if (error?.message === ResponseStatus.Canceled) return;
 
       AppLog.error(error);
+
+      if (isUnsupportedPage(error?.response)) {
+        dispatch(settingsActions.setPageNotFoundStatus(true));
+
+        return;
+      }
 
       // set NFTS failed to load
       dispatch(

--- a/src/store/features/settings/settings-slice.ts
+++ b/src/store/features/settings/settings-slice.ts
@@ -12,6 +12,7 @@ export interface SettingsState {
   displayPriceApplyButton: boolean;
   showAlerts: boolean;
   assetsToWithdraw: AlertsData[];
+  showPageNotFound: boolean;
 }
 
 const initialState: SettingsState = {
@@ -19,6 +20,7 @@ const initialState: SettingsState = {
   displayPriceApplyButton: false,
   showAlerts: false,
   assetsToWithdraw: [],
+  showPageNotFound: false,
 };
 
 export const settingsSlice = createSlice({
@@ -41,6 +43,12 @@ export const settingsSlice = createSlice({
       }
 
       state.showAlerts = true;
+    },
+    setPageNotFoundStatus: (
+      state,
+      action: PayloadAction<boolean>,
+    ) => {
+      state.showPageNotFound = action.payload;
     },
   },
 });

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -79,7 +79,7 @@ export const errorMessageHandler = (err: Err) => {
 };
 
 export const isUnsupportedPage = (error: ErrorParams) => {
-  if (error.data === ResponseStatus.UnsupportedCollection)
+  if (!error || error.data === ResponseStatus.UnsupportedCollection)
     return true;
 
   return false;

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,4 +1,12 @@
+import { ResponseStatus } from '../constants/response-status';
+
 type Err = Record<string, any>;
+
+type ErrorParams = {
+  data: string;
+  status: number;
+  statusText?: string;
+};
 
 const toErrorMessage = (errorKey: string) => {
   console.warn(errorKey);
@@ -70,3 +78,9 @@ export const errorMessageHandler = (err: Err) => {
   }
 };
 
+export const isUnsupportedPage = (error: ErrorParams) => {
+  if (error.data === ResponseStatus.UnsupportedCollection)
+    return true;
+
+  return false;
+};

--- a/src/views/CollectionView/index.tsx
+++ b/src/views/CollectionView/index.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { CollectionOverview, CollectionTabs } from '../../components';
-import { Container, CollectionWrapper } from './styles';
+import PageNotFoundView from '../PageNotFoundView';
+import {
+  Container,
+  CollectionContainer,
+  CollectionWrapper,
+} from './styles';
 import { useSettingsStore } from '../../store';
 
 /* --------------------------------------------------------------------------
@@ -8,14 +13,20 @@ import { useSettingsStore } from '../../store';
  * --------------------------------------------------------------------------*/
 
 const CollectionView = () => {
-  const { showAlerts } = useSettingsStore();
+  const { showAlerts, showPageNotFound } = useSettingsStore();
 
   return (
     <Container>
-      <CollectionWrapper showAlerts={showAlerts}>
-        <CollectionOverview />
-      </CollectionWrapper>
-      <CollectionTabs />
+      {!showPageNotFound ? (
+        <CollectionContainer>
+          <CollectionWrapper showAlerts={showAlerts}>
+            <CollectionOverview />
+          </CollectionWrapper>
+          <CollectionTabs />
+        </CollectionContainer>
+      ) : (
+        <PageNotFoundView />
+      )}
     </Container>
   );
 };

--- a/src/views/CollectionView/styles.ts
+++ b/src/views/CollectionView/styles.ts
@@ -8,6 +8,10 @@ export const Container = styled('div', {
   },
 });
 
+export const CollectionContainer = styled('div', {
+  width: '100%',
+});
+
 export const CollectionWrapper = styled('div', {
   paddingTop: '72px',
 

--- a/src/views/NFTView/index.tsx
+++ b/src/views/NFTView/index.tsx
@@ -2,13 +2,14 @@ import { useEffect } from 'react';
 import { NFTActivityTable, NftDetails } from '../../components';
 import { Container, NFTDetailsWrapper } from './styles';
 import { useSettingsStore } from '../../store';
+import PageNotFoundView from '../PageNotFoundView';
 
 /* --------------------------------------------------------------------------
  * NFT View Component
  * --------------------------------------------------------------------------*/
 
 const NFTView = () => {
-  const { showAlerts } = useSettingsStore();
+  const { showAlerts, showPageNotFound } = useSettingsStore();
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -16,10 +17,14 @@ const NFTView = () => {
 
   return (
     <Container showAlerts={showAlerts}>
-      <NFTDetailsWrapper>
-        <NftDetails />
-        <NFTActivityTable />
-      </NFTDetailsWrapper>
+      {!showPageNotFound ? (
+        <NFTDetailsWrapper>
+          <NftDetails />
+          <NFTActivityTable />
+        </NFTDetailsWrapper>
+      ) : (
+        <PageNotFoundView />
+      )}
     </Container>
   );
 };

--- a/src/views/PageNotFoundView/index.tsx
+++ b/src/views/PageNotFoundView/index.tsx
@@ -1,0 +1,45 @@
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ActionButton } from '../../components/core';
+import {
+  Container,
+  NotFoundWrapper,
+  NotFoundIcon,
+  NotFoundText,
+  ButtonWrapper,
+} from './styles';
+
+/* --------------------------------------------------------------------------
+ * Page Not Found View
+ * --------------------------------------------------------------------------*/
+
+const PageNotFoundView = () => {
+  const { t } = useTranslation();
+
+  const navigate = useNavigate();
+
+  const handleViewCollections = () => {
+    navigate('/', { replace: true });
+  };
+
+  return (
+    <Container>
+      <NotFoundWrapper>
+        <NotFoundIcon>404</NotFoundIcon>
+        <NotFoundText>
+          We can't find the page that you're looking for
+        </NotFoundText>
+        <ButtonWrapper>
+          <ActionButton
+            type="primary"
+            onClick={handleViewCollections}
+          >
+            Take me home
+          </ActionButton>
+        </ButtonWrapper>
+      </NotFoundWrapper>
+    </Container>
+  );
+};
+
+export default PageNotFoundView;

--- a/src/views/PageNotFoundView/index.tsx
+++ b/src/views/PageNotFoundView/index.tsx
@@ -25,16 +25,18 @@ const PageNotFoundView = () => {
   return (
     <Container>
       <NotFoundWrapper>
-        <NotFoundIcon>404</NotFoundIcon>
+        <NotFoundIcon>
+          {t('translation:emptyStates.notFoundTitle')}
+        </NotFoundIcon>
         <NotFoundText>
-          We can't find the page that you're looking for
+          {t('translation:emptyStates.notFoundDescription')}
         </NotFoundText>
         <ButtonWrapper>
           <ActionButton
             type="primary"
             onClick={handleViewCollections}
           >
-            Take me home
+            {t('translation:emptyStates.homeButton')}
           </ActionButton>
         </ButtonWrapper>
       </NotFoundWrapper>

--- a/src/views/PageNotFoundView/index.tsx
+++ b/src/views/PageNotFoundView/index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ActionButton } from '../../components/core';
+import { useAppDispatch, settingsActions } from '../../store';
 import {
   Container,
   NotFoundWrapper,
@@ -15,10 +16,12 @@ import {
 
 const PageNotFoundView = () => {
   const { t } = useTranslation();
+  const dispatch = useAppDispatch();
 
   const navigate = useNavigate();
 
   const handleViewCollections = () => {
+    dispatch(settingsActions.setPageNotFoundStatus(false));
     navigate('/', { replace: true });
   };
 

--- a/src/views/PageNotFoundView/styles.ts
+++ b/src/views/PageNotFoundView/styles.ts
@@ -7,6 +7,7 @@ export const Container = styled('div', {
 });
 
 export const NotFoundWrapper = styled('div', {
+  minHeight: 'calc(100vh - 300px)',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',

--- a/src/views/PageNotFoundView/styles.ts
+++ b/src/views/PageNotFoundView/styles.ts
@@ -2,17 +2,16 @@ import { styled } from '../../stitches.config';
 
 export const Container = styled('div', {
   backgroundColor: '$primaryBackgroundColor',
-  paddingTop: '120px',
   overflow: 'hidden',
 });
 
 export const NotFoundWrapper = styled('div', {
-  minHeight: 'calc(100vh - 300px)',
+  minHeight: 'calc(100vh - 80px)',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
-  margin: '28px auto',
+  margin: 'auto',
 });
 
 export const NotFoundIcon = styled('div', {

--- a/src/views/PageNotFoundView/styles.ts
+++ b/src/views/PageNotFoundView/styles.ts
@@ -1,0 +1,47 @@
+import { styled } from '../../stitches.config';
+
+export const Container = styled('div', {
+  backgroundColor: '$primaryBackgroundColor',
+  paddingTop: '120px',
+  overflow: 'hidden',
+});
+
+export const NotFoundWrapper = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '28px auto',
+});
+
+export const NotFoundIcon = styled('div', {
+  fontSize: '200px',
+  fontWeight: '700',
+  lineHeight: '1',
+  marginBottom: '24px',
+});
+
+export const NotFoundText = styled('p', {
+  fontStyle: 'normal',
+  fontWeight: '700',
+  fontSize: '24px',
+  lineHeight: '1',
+  color: '$mainTextColor',
+  marginBottom: '24px',
+
+  '@md': {
+    textAlign: 'center',
+    fontSize: '16px',
+    fontWeight: '600',
+  },
+});
+
+export const ButtonWrapper = styled('div', {
+  height: '50px',
+  margin: '10px',
+  minWidth: '180px',
+
+  '@md': {
+    width: '250px',
+  },
+});


### PR DESCRIPTION
## Why?

Show Page not found UI when user tries to fetch unknown collection or NFT

## How?

- [x] create page not found UI component 
- [x] handle 500 response error when user tries to fetch unknown collection details
- [x] handle 500 response error when user tries to fetch unknown NFT details
- [x] add route to handle collection not found UI in root

## Demo?

<img width="1430" alt="Screenshot 2022-08-23 at 4 56 55 PM" src="https://user-images.githubusercontent.com/40259256/186146603-32402d5f-6ed5-49d5-9152-ce1b2c4436ee.png">


https://user-images.githubusercontent.com/40259256/186335176-6b005e4b-d9a3-4050-8c5e-ddf322ca6cb8.mov

