### PR TITLE
fix: 🐛 insufficient balance error while making offer and direct buy

### DIFF
--- a/src/components/modals/buy-now-modal.tsx
+++ b/src/components/modals/buy-now-modal.tsx
@@ -68,7 +68,7 @@ export const BuyNowModal = ({
     DirectBuyStatusCodes.Pending,
   );
 
-  const { loadingWicpBalance, walletsWICPBalance } = usePlugStore();
+  const { loadingWicpBalance, wicpBalance } = usePlugStore();
 
   const transactionSteps = useSelector(
     (state: RootState) => state.marketplace.transactionSteps,
@@ -102,7 +102,7 @@ export const BuyNowModal = ({
       isBalanceInsufficient({
         loadingWicpBalance,
         amountRequired: Number(price),
-        walletsWICPBalance,
+        walletsWICPBalance: Number(wicpBalance),
       })
     ) {
       setModalStep(DirectBuyStatusCodes.InsufficientBalance);

--- a/src/components/modals/make-offer-modal.tsx
+++ b/src/components/modals/make-offer-modal.tsx
@@ -77,7 +77,7 @@ export const MakeOfferModal = ({
 
   const tokenId = useMemo(() => id || nftTokenId, [id, nftTokenId]);
 
-  const { loadingWicpBalance, walletsWICPBalance } = usePlugStore();
+  const { loadingWicpBalance, wicpBalance } = usePlugStore();
 
   useEffect(() => {
     if (!offerPrice || !modalOpened) return;
@@ -107,7 +107,7 @@ export const MakeOfferModal = ({
       isBalanceInsufficient({
         loadingWicpBalance,
         amountRequired: Number(amount),
-        walletsWICPBalance,
+        walletsWICPBalance: Number(wicpBalance),
       })
     ) {
       setModalStep(ListingStatusCodes.InsufficientBalance);


### PR DESCRIPTION
## Why?

Fix insufficient balance error while making offer and direct buy

## How?

- [x] update `Wallets WICP balance` in `make offer modal`
- [x] update `Wallets WICP balance` in `buy now modal`

## Demo?

Issue: 


https://user-images.githubusercontent.com/40259256/186343541-59dea9f8-5775-425c-a1a0-087bee16875e.mov

Fix:


https://user-images.githubusercontent.com/40259256/186343986-78da63b3-57ae-4442-89ff-655ed9f2f0a5.mov


