### PR TITLE
chore: 🤖 added jelly-hub canister id as env var

### DIFF
--- a/.scripts/start.sh
+++ b/.scripts/start.sh
@@ -7,6 +7,7 @@ env="${1:-$defaultEnv}"
 printf "🤖 Start env (%s)\n" "$env"
 
 if [[ $env == "development" ]]; then
+  HUB_ID=$(cd ./jelly && dfx canister id jelly-hub)
   MKP_ID=$(cd nft-marketplace && dfx canister id marketplace)
   CROWNS_ID=$(cd jelly && dfx canister id crowns)
   WICP_ID=$(cd jelly && dfx canister id wicp) 
@@ -14,6 +15,7 @@ if [[ $env == "development" ]]; then
 
   printf "🤖 Marketplace id (%s), CrownsId (%s), WicpId (%s), CapId (%s)\n" "$MKP_ID" "$CROWNS_ID" "$WICP_ID" "$CAP_ID"
 
+  REACT_APP_HUB_ID=$HUB_ID \
   REACT_APP_MARKETPLACE_ID=$MKP_ID \
   REACT_APP_CROWNS_ID=$CROWNS_ID  \
   REACT_APP_WICP_ID=$WICP_ID  \


### PR DESCRIPTION
## Why?

For jelly-js it's necessary to have a `REACT_APP_HUB_ID` env var with the jelly-hub canister id in development mode. So in the start.sh script that variable was added.

For more information on this, refer to the jelly-js pull request with [this feature](https://github.com/Psychedelic/jelly-js/pulls)

## Demo?

REACT_APP_HUB_ID is consoled logged and getCollections is performed correctly:
![image](https://user-images.githubusercontent.com/5349650/187968990-6308a5c9-0c7f-415e-988d-e373e1bcc843.png)



