### PR TITLE
feat: 🎸 nft listing pagination

### DIFF
--- a/src/components/nft-list/nft-list.tsx
+++ b/src/components/nft-list/nft-list.tsx
@@ -23,8 +23,13 @@ export const NftList = () => {
   const { t } = useTranslation();
   // eslint-disable-next-line
   const dispatch = useAppDispatch();
-  const { loadedNFTS, hasMoreNFTs, loadingNFTs, nextPageNo } =
-    useNFTSStore();
+  const {
+    loadedNFTS,
+    hasMoreNFTs,
+    loadingNFTs,
+    nextPageNo,
+    lastIndexValue,
+  } = useNFTSStore();
   const { collectionId } = useParams();
   const { isMyNfts, status, defaultFilters } = useFilterStore();
   const { principalId, isConnected } = usePlugStore();
@@ -69,7 +74,7 @@ export const NftList = () => {
         payload,
         sort: sortBy,
         order: 'd',
-        page: nextPageNo,
+        page: lastIndexValue,
         count: 25,
         collectionId,
       }),

--- a/src/integrations/kyasshu/index.ts
+++ b/src/integrations/kyasshu/index.ts
@@ -65,7 +65,6 @@ export const useNFTSFetcher = () => {
         payload,
         sort: sortBy,
         order: 'd',
-        page: 0,
         count: 25,
         collectionId,
       }),

--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -57,11 +57,10 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
         collection,
       );
 
-      // const lastIndex = BigInt(page);
+      const lastIndex = page && BigInt(page);
       const res = await jellyCollection.getAllNFTs({
         count: BigInt(count),
-        // TODO: lastIndex to control pagination
-        // lastIndex,
+        lastIndex,
       });
 
       const { data, total, lastIndex: responseLastIndex } = res;
@@ -95,6 +94,7 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
         total,
         nextPage:
           Math.floor(Number(total) / Number(responseLastIndex)) + 1,
+        lastIndex: responseLastIndex,
       };
 
       // update store with loaded NFTS details
@@ -123,4 +123,3 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
     }
   },
 );
-

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -22,6 +22,7 @@ interface NFTSState {
   floorPrice: number;
   totalVolume: number;
   allNFTs: any[];
+  lastIndexValue: number | undefined;
 }
 
 // Define the initial state using that type
@@ -38,6 +39,7 @@ const initialState: NFTSState = {
   floorPrice: 0,
   totalVolume: 0,
   allNFTs: [],
+  lastIndexValue: undefined,
 };
 
 export interface LoadedNFTData {
@@ -45,6 +47,7 @@ export interface LoadedNFTData {
   totalPages: number;
   total: number;
   nextPage: number;
+  lastIndex: number;
 }
 
 interface ListedNFTData {
@@ -94,8 +97,10 @@ export const nftsSlice = createSlice({
       }
     },
     setLoadedNFTS: (state, action: PayloadAction<LoadedNFTData>) => {
-      const { loadedNFTList, totalPages, nextPage } = action.payload;
+      const { loadedNFTList, totalPages, nextPage, lastIndex } =
+        action.payload;
       state.loadingNFTs = false;
+      state.lastIndexValue = Number(lastIndex);
       if (nextPage === 1) {
         state.loadedNFTS = loadedNFTList;
       } else {


### PR DESCRIPTION
## Why?

Nft listing pagination

## How?

- Created new redux state to store the lastIndex value
- Pulled in the lastIndex value from the store and passed into the loadMore function for loading more nfts

## Tickets?

- [GH Pages](https://github.com/orgs/Psychedelic/projects/6/views/11)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/188767714-1257265b-0f3c-41b9-95c5-172348846e90.mov
