### PR TITLE
fix: 🐛 first index of mock gen start at zero

### DIFF
--- a/.scripts/generate-mocked-tokens-v2.sh
+++ b/.scripts/generate-mocked-tokens-v2.sh
@@ -91,7 +91,8 @@ printf "👍 Mint process completed!\n\n"
 
   echo "🧙‍♀️ Will now insert the metadata for the total supply $totalSupply, be patient..."
 
-  for ((i=1; i <= "$totalSupply"; i++))
+  firstIndex=0
+  for ((i="$firstIndex"; i <= "$totalSupply"; i++))
   do
     crownsNftCanisterId="vlhm2-4iaaa-aaaam-qaatq-cai"
     filename=$(printf "%04d.mp4" "$i")


### PR DESCRIPTION
## Why?

Currently, the first mock id is 1 but should be 0. The mock generator should insert from zero.

## Demo?

<img width="547" alt="Screenshot 2022-09-07 at 11 19 16" src="https://user-images.githubusercontent.com/236752/188854643-cf024ebd-a910-4409-a186-fc92ce2c0f5c.png">

