### PR TITLE
fix: 🐛 pagination last index, offset index

### DIFF
--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
-import { nftsActions } from '../nfts-slice';
+import { nftsActions, LoadedNFTData } from '../nfts-slice';
 import { marketplaceSlice } from '../../marketplace/marketplace-slice';
 import { NSKyasshuUrl } from '../../../../integrations/kyasshu';
 import { isEmptyObject } from '../../../../utils/common';
@@ -87,14 +87,17 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
         return metadata;
       });
 
-      const actionPayload = {
+      const actionPayload: LoadedNFTData = {
         loadedNFTList: extractedNFTSList,
         totalPages: Math.ceil(Number(total) / count),
         total,
         nextPage:
           Math.floor(Number(total) / Number(responseLastIndex)) + 1,
-        lastIndex: responseLastIndex,
       };
+
+      if (responseLastIndex) {
+        actionPayload.lastIndex = Number(responseLastIndex) - 1;
+      }
 
       // update store with loaded NFTS details
       dispatch(nftsActions.setLoadedNFTS(actionPayload));


### PR DESCRIPTION
## Why?

The pagination should offset by 1, as it currently skips index 1 and shows 2 as the minimal.

## Demo?

<img width="1068" alt="Screenshot 2022-09-08 at 12 25 02" src="https://user-images.githubusercontent.com/236752/189110381-49261084-c175-4159-af98-413bf671092d.png">
