### PR TITLE
fix: 🐛 pagination stop hydration

### DIFF
--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
-import { nftsActions } from '../nfts-slice';
+import { nftsActions, LoadedNFTData } from '../nfts-slice';
 import { marketplaceSlice } from '../../marketplace/marketplace-slice';
 import { NSKyasshuUrl } from '../../../../integrations/kyasshu';
 import { isEmptyObject } from '../../../../utils/common';
@@ -87,14 +87,17 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
         return metadata;
       });
 
-      const actionPayload = {
+      const actionPayload: LoadedNFTData = {
         loadedNFTList: extractedNFTSList,
         totalPages: Math.ceil(Number(total) / count),
         total,
         nextPage:
           Math.floor(Number(total) / Number(responseLastIndex)) + 1,
-        lastIndex: responseLastIndex,
       };
+
+      if (responseLastIndex) {
+        actionPayload.lastIndex = Number(responseLastIndex) - 1;
+      }
 
       // update store with loaded NFTS details
       dispatch(nftsActions.setLoadedNFTS(actionPayload));

--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -35,6 +35,14 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
     });
 
     const { dispatch } = thunkAPI;
+    const {
+      nfts: { hasMoreNFTs },
+    } = thunkAPI.getState() as any;
+
+    // TODO: should move to the UI side to make this more reusable
+    // and controlled from client use-case only
+    // Prevent pagination
+    if (typeof hasMoreNFTs !== 'undefined' && !hasMoreNFTs) return;
 
     // set loading NFTS state to true
     dispatch(nftsActions.setIsNFTSLoading(true));

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -14,7 +14,7 @@ interface NFTSState {
   loadedNFTS: NFTMetadata[];
   failedToLoadNFTS: boolean;
   failedToLoadNFTSMessage: string;
-  hasMoreNFTs: boolean;
+  hasMoreNFTs?: boolean;
   nextPageNo: number;
   loadingCollectionData: boolean;
   totalNFTSCount: number;
@@ -31,7 +31,6 @@ const initialState: NFTSState = {
   loadedNFTS: [],
   failedToLoadNFTS: false,
   failedToLoadNFTSMessage: '',
-  hasMoreNFTs: false,
   nextPageNo: 0,
   loadingCollectionData: false,
   totalNFTSCount: 0,
@@ -47,7 +46,7 @@ export interface LoadedNFTData {
   totalPages: number;
   total: number;
   nextPage: number;
-  lastIndex: number;
+  lastIndex?: number;
 }
 
 interface ListedNFTData {
@@ -115,7 +114,8 @@ export const nftsSlice = createSlice({
     },
     clearLoadedNFTS: (state) => {
       state.loadedNFTS = [];
-      state.hasMoreNFTs = false;
+      // Only defined once checked at least once
+      state.hasMoreNFTs = undefined;
       state.nextPageNo = 0;
     },
     setFailedToLoadNFTS: (state, action: PayloadAction<boolean>) => {


### PR DESCRIPTION
## Why?

It should stop hydrating page data after reaching the total.

⚠️ Depends on https://github.com/Psychedelic/nft-marketplace-fe/pull/515 which should go first

## Demo?


https://user-images.githubusercontent.com/236752/189121732-e1ae22b2-8467-4ffb-bd02-9ca333b4ac1b.mp4

