### PR TITLE
feat: 🎸 make offer integration using jelly js (initial)

### DIFF
--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -89,7 +89,7 @@ export const OnConnected = ({
   showNFTActionButtons,
   operator,
 }: ConnectedProps) => {
-  const { id } = useParams();
+  const { id, collectionId } = useParams();
   const dispatch = useAppDispatch();
   const [loadingOffers, setLoadingOffers] = useState<boolean>(true);
   const { principalId: plugPrincipalId } = usePlugStore();
@@ -106,27 +106,29 @@ export const OnConnected = ({
     (state: RootState) => state.marketplace.recentlyCancelledOffers,
   );
 
-  const tokenOffers = useSelector(
-    (state: RootState) => state.marketplace.tokenOffers,
+  const nftOffers = useSelector(
+    (state: RootState) => state.marketplace.nftOffers,
   );
 
-  const userMadeOffer: OffersTableItem = useMemo(
+  // TODO: offers Item type
+  const userMadeOffer: any = useMemo(
     () =>
-      tokenOffers.find(
-        (offer: OffersTableItem) =>
-          offer?.fromDetails?.address === plugPrincipalId &&
-          offer?.item?.tokenId.toString() === id,
+      nftOffers.find(
+        (offer: any) =>
+          offer?.buyer.toString() === plugPrincipalId &&
+          offer?.tokenId === id,
       ),
-    [id, tokenOffers, plugPrincipalId],
+    [id, nftOffers, plugPrincipalId],
   );
 
   useEffect(() => {
     // TODO: handle the error gracefully when there is no id
-    if (!id || !plugPrincipalId) return;
+    if (!id || !collectionId || !plugPrincipalId) return;
 
     dispatch(
-      marketplaceActions.getTokenOffers({
-        ownerTokenIdentifiers: [BigInt(id)],
+      marketplaceActions.getNFTOffers({
+        id,
+        collectionId,
 
         onSuccess: () => {
           setLoadingOffers(false);
@@ -191,10 +193,7 @@ export const OnConnected = ({
             showNonOwnerButtons && !loadingOffers && userMadeOffer,
           )}
         >
-          <CancelOfferModal
-            item={userMadeOffer?.item}
-            largeTriggerButton
-          />
+          <CancelOfferModal item={userMadeOffer} largeTriggerButton />
         </ButtonDetailsWrapper>
       )}
     </ButtonListWrapper>

--- a/src/components/modals/cancel-offer-modal.tsx
+++ b/src/components/modals/cancel-offer-modal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { ActionButton, Pending } from '../core';
@@ -36,6 +37,7 @@ export const CancelOfferModal = ({
 }: CancelOfferModalProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
+  const { collectionId } = useParams();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
   // Cancel offer modal steps: cancelOffer/pending
@@ -53,13 +55,14 @@ export const CancelOfferModal = ({
   };
 
   const handleCancelOffer = () => {
-    if (!item?.tokenId) return;
+    if (!item?.tokenId || !collectionId) return;
 
     setModalStep(ListingStatusCodes.Pending);
 
     dispatch(
       marketplaceActions.cancelOffer({
         id: item?.tokenId.toString(),
+        collectionId: collectionId,
         onSuccess: () => {
           setModalOpened(false);
 

--- a/src/store/features/marketplace/async-thunks/get-nft-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-nft-offers.ts
@@ -1,0 +1,76 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
+import { getJellyCollection } from '../../../../utils/jelly';
+import {
+  marketplaceActions,
+  marketplaceSlice,
+} from '../marketplace-slice';
+import { notificationActions } from '../../notifications';
+import { AppLog } from '../../../../utils/log';
+
+// TODO: delete getTokenOffers thunk when getNFTOffers is ready
+// to render NFT offers list
+
+export const getNFTOffers = createAsyncThunk<any | undefined, any>(
+  'marketplace/getNFTOffers',
+  async ({ collectionId, id, onSuccess, onFailure }, thunkAPI) => {
+    // Checks if an actor instance exists already
+    // otherwise creates a new instance
+    const jellyInstance = await jellyJsInstanceHandler({
+      thunkAPI,
+      collectionId: collectionId.toString(),
+      slice: marketplaceSlice,
+    });
+
+    const collection = await getJellyCollection({
+      jellyInstance,
+      collectionId: collectionId.toString(),
+    });
+
+    if (!collection)
+      throw Error(`Oops! collection ${collectionId} not found!`);
+
+    const jellyCollection = await jellyInstance.getJellyCollection(
+      collection,
+    );
+
+    thunkAPI.dispatch(marketplaceActions.setOffersLoaded(false));
+
+    try {
+      const result = await jellyCollection.getNFTs({
+        ids: [id],
+      });
+
+      const { data, ok } = result;
+
+      if (!ok)
+        throw Error(`Oops! Failed to get token offers for id ${id}`);
+
+      const item = data.pop();
+      const { offers } = item;
+
+      if (!offers) throw Error('Oops! Offers not found!');
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      typeof onSuccess === 'function' && onSuccess();
+
+      thunkAPI.dispatch(marketplaceActions.setOffersLoaded(true));
+
+      // TODO: parse NFT offers response
+
+      return offers;
+    } catch (err) {
+      AppLog.error(err);
+      thunkAPI.dispatch(
+        notificationActions.setErrorMessage(
+          `Oops! Failed to get token offers`,
+        ),
+      );
+      if (typeof onFailure === 'function') {
+        onFailure(err);
+      }
+
+      return [];
+    }
+  },
+);

--- a/src/store/features/marketplace/async-thunks/index.ts
+++ b/src/store/features/marketplace/async-thunks/index.ts
@@ -11,3 +11,4 @@ export * from './get-floor-price';
 export * from './get-collections';
 export * from './get-assets-to-withdraw';
 export * from './withdraw-fungible';
+export * from './get-nft-offers';

--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -54,13 +54,13 @@ export const makeOffer = createAsyncThunk<
 
   const { marketplaceId } = collection;
 
+  const userOwnedTokenId = BigInt(id);
+  const userOfferInPrice = parseAmountToE8S(amount);
+
+  // Allowance amount calculation
   const {
     marketplace: { sumOfUserAllowance },
   }: any = getState();
-
-  const crownsContractAddress = Principal.fromText(collectionId);
-  const userOwnedTokenId = BigInt(id);
-  const userOfferInPrice = parseAmountToE8S(amount);
 
   const allowanceAmountInWICP = sumOfUserAllowance
     ? sumOfUserAllowance + Number(amount)
@@ -70,6 +70,7 @@ export const makeOffer = createAsyncThunk<
     allowanceAmountInWICP.toString(),
   );
 
+  // Initialize transaction steps in UI
   dispatch(marketplaceActions.setTransactionStepsToDefault());
 
   try {
@@ -101,11 +102,7 @@ export const makeOffer = createAsyncThunk<
       idl: marketplaceV2IdlFactory,
       canisterId: config.marketplaceCanisterId,
       methodName: 'makeOffer',
-      args: [
-        crownsContractAddress,
-        userOwnedTokenId,
-        userOfferInPrice,
-      ],
+      args: [collection.id, userOwnedTokenId, userOfferInPrice],
       onSuccess: async (res: any) => {
         if ('Err' in res)
           throw new Error(errorMessageHandler(res.Err));

--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -1,4 +1,3 @@
-import { Principal } from '@dfinity/principal';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 import { notificationActions } from '../../notifications';

--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -98,11 +98,22 @@ export const makeOffer = createAsyncThunk<
       },
     };
 
-    const MKP_MAKE_OFFER_WICP = {
+    const MKP_MAKE_OFFER = {
       idl: marketplaceV2IdlFactory,
-      canisterId: config.marketplaceCanisterId,
-      methodName: 'makeOffer',
-      args: [collection.id, userOwnedTokenId, userOfferInPrice],
+      canisterId: marketplaceId.toString(),
+      methodName: 'make_offer',
+      args: [
+        {
+          token_id: userOwnedTokenId.toString(),
+          collection: collection.id,
+          seller: [],
+          version: [],
+          fungible_id: [],
+          caller: [],
+          buyer: [],
+          price: [userOfferInPrice],
+        },
+      ],
       onSuccess: async (res: any) => {
         if ('Err' in res)
           throw new Error(errorMessageHandler(res.Err));
@@ -132,7 +143,7 @@ export const makeOffer = createAsyncThunk<
     // TODO: Show transaction progress steps in UI
     const batchTxRes = await window.ic?.plug?.batchTransactions([
       WICP_APPROVE_MARKETPLACE,
-      MKP_MAKE_OFFER_WICP,
+      MKP_MAKE_OFFER,
     ]);
 
     if (!batchTxRes) {

--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -9,7 +9,7 @@ import {
 } from '../marketplace-slice';
 import config from '../../../../config/env';
 import wicpIdlFactory from '../../../../declarations/wicp.did';
-import marketplaceIdlFactory from '../../../../declarations/marketplace.did';
+import marketplaceV2IdlFactory from '../../../../declarations/marketplace-v2.did';
 import { AppLog } from '../../../../utils/log';
 import { parseAmountToE8S } from '../../../../utils/formatters';
 import { errorMessageHandler } from '../../../../utils/error';
@@ -73,7 +73,7 @@ export const makeOffer = createAsyncThunk<
     };
 
     const MKP_MAKE_OFFER_WICP = {
-      idl: marketplaceIdlFactory,
+      idl: marketplaceV2IdlFactory,
       canisterId: config.marketplaceCanisterId,
       methodName: 'makeOffer',
       args: [

--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -23,8 +23,10 @@ export type MakeOfferProps = DefaultCallbacks &
 export const makeOffer = createAsyncThunk<
   MakeOffer | undefined,
   MakeOfferProps
->('marketplace/makeOffer', async (params, { dispatch, getState }) => {
+>('marketplace/makeOffer', async (params, thunkAPI) => {
   const { id, amount, collectionId, onSuccess, onFailure } = params;
+
+  const { dispatch, getState } = thunkAPI;
 
   const {
     marketplace: { sumOfUserAllowance },

--- a/src/store/features/marketplace/marketplace-slice.ts
+++ b/src/store/features/marketplace/marketplace-slice.ts
@@ -23,6 +23,7 @@ import {
   getCollections,
   getAssetsToWithdraw,
   withdrawFungible,
+  getNFTOffers,
 } from './async-thunks';
 import { TransactionStatus } from '../../../constants/transaction-status';
 
@@ -95,6 +96,8 @@ type InitialState = {
   transactionSteps: TransactionStepsStatus;
   // TODO: jelly-js type
   jellyJsInstance: any;
+  // TODO: NFT offers type
+  nftOffers: any;
 };
 
 const defaultTransactionStatus = {
@@ -120,6 +123,7 @@ const initialState: InitialState = {
   offersLoaded: false,
   transactionSteps: defaultTransactionStatus,
   jellyJsInstance: {},
+  nftOffers: [],
 };
 
 export const marketplaceSlice = createSlice({
@@ -213,6 +217,11 @@ export const marketplaceSlice = createSlice({
 
       state.recentlyWithdrawnAssets.push(action.payload);
     });
+    builder.addCase(getNFTOffers.fulfilled, (state, action) => {
+      if (!action.payload) return;
+
+      state.nftOffers = action.payload;
+    });
   },
 });
 
@@ -231,6 +240,7 @@ export const marketplaceActions = {
   getCollections,
   getAssetsToWithdraw,
   withdrawFungible,
+  getNFTOffers,
 };
 
 export default marketplaceSlice.reducer;


### PR DESCRIPTION
## Why?

Should have an initial implementation of make offer.

## How?

- [x] Integrate `jelly-js` to fetch marketplace Id and collection details
- [x] update `make offer` thunk to support latest marketplace v2 and jelly-js

## Note?

- `jelly-js` make_offer creates multiple popups as it does not use plug batch, was reported.

## Tickets?

- [issue-504([the-ticket-url-here](https://github.com/Psychedelic/nft-marketplace-fe/issues/504))

## Demo?


https://user-images.githubusercontent.com/40259256/189271670-f4aefec3-f6df-4d89-b555-b302b091f83f.mov


