### PR TITLE
feat: 🎸 enable edit offer integration using jelly js

### DIFF
--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -89,7 +89,7 @@ export const OnConnected = ({
   showNFTActionButtons,
   operator,
 }: ConnectedProps) => {
-  const { id } = useParams();
+  const { id, collectionId } = useParams();
   const dispatch = useAppDispatch();
   const [loadingOffers, setLoadingOffers] = useState<boolean>(true);
   const { principalId: plugPrincipalId } = usePlugStore();
@@ -106,27 +106,29 @@ export const OnConnected = ({
     (state: RootState) => state.marketplace.recentlyCancelledOffers,
   );
 
-  const tokenOffers = useSelector(
-    (state: RootState) => state.marketplace.tokenOffers,
+  const nftOffers = useSelector(
+    (state: RootState) => state.marketplace.nftOffers,
   );
 
-  const userMadeOffer: OffersTableItem = useMemo(
+  // TODO: offers Item type
+  const userMadeOffer: any = useMemo(
     () =>
-      tokenOffers.find(
-        (offer: OffersTableItem) =>
-          offer?.fromDetails?.address === plugPrincipalId &&
-          offer?.item?.tokenId.toString() === id,
+      nftOffers.find(
+        (offer: any) =>
+          offer?.buyer.toString() === plugPrincipalId &&
+          offer?.tokenId === id,
       ),
-    [id, tokenOffers, plugPrincipalId],
+    [id, nftOffers, plugPrincipalId],
   );
 
   useEffect(() => {
     // TODO: handle the error gracefully when there is no id
-    if (!id || !plugPrincipalId) return;
+    if (!id || !collectionId || !plugPrincipalId) return;
 
     dispatch(
-      marketplaceActions.getTokenOffers({
-        ownerTokenIdentifiers: [BigInt(id)],
+      marketplaceActions.getNFTOffers({
+        id,
+        collectionId,
 
         onSuccess: () => {
           setLoadingOffers(false);

--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -193,10 +193,7 @@ export const OnConnected = ({
             showNonOwnerButtons && !loadingOffers && userMadeOffer,
           )}
         >
-          <CancelOfferModal
-            item={userMadeOffer?.item}
-            largeTriggerButton
-          />
+          <CancelOfferModal item={userMadeOffer} largeTriggerButton />
         </ButtonDetailsWrapper>
       )}
     </ButtonListWrapper>

--- a/src/components/modals/cancel-offer-modal.tsx
+++ b/src/components/modals/cancel-offer-modal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { ActionButton, Pending } from '../core';
@@ -36,6 +37,7 @@ export const CancelOfferModal = ({
 }: CancelOfferModalProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
+  const { collectionId } = useParams();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
   // Cancel offer modal steps: cancelOffer/pending
@@ -53,13 +55,14 @@ export const CancelOfferModal = ({
   };
 
   const handleCancelOffer = () => {
-    if (!item?.tokenId) return;
+    if (!item?.tokenId || !collectionId) return;
 
     setModalStep(ListingStatusCodes.Pending);
 
     dispatch(
       marketplaceActions.cancelOffer({
         id: item?.tokenId.toString(),
+        collectionId: collectionId,
         onSuccess: () => {
           setModalOpened(false);
 

--- a/src/store/features/marketplace/async-thunks/get-nft-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-nft-offers.ts
@@ -1,0 +1,75 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
+import { getJellyCollection } from '../../../../utils/jelly';
+import {
+  marketplaceActions,
+  marketplaceSlice,
+} from '../marketplace-slice';
+import { notificationActions } from '../../notifications';
+import { AppLog } from '../../../../utils/log';
+
+export const getNFTOffers = createAsyncThunk<any | undefined, any>(
+  'marketplace/getNFTOffers',
+  async ({ collectionId, id, onSuccess, onFailure }, thunkAPI) => {
+    // Checks if an actor instance exists already
+    // otherwise creates a new instance
+    const jellyInstance = await jellyJsInstanceHandler({
+      thunkAPI,
+      collectionId: collectionId.toString(),
+      slice: marketplaceSlice,
+    });
+
+    const collection = await getJellyCollection({
+      jellyInstance,
+      collectionId: collectionId.toString(),
+    });
+
+    if (!collection)
+      throw Error(`Oops! collection ${collectionId} not found!`);
+
+    const jellyCollection = await jellyInstance.getJellyCollection(
+      collection,
+    );
+
+    thunkAPI.dispatch(marketplaceActions.setOffersLoaded(false));
+
+    try {
+      const result = await jellyCollection.getNFTs({
+        ids: [id],
+      });
+
+      const { data, ok } = result;
+
+      if (!ok)
+        throw Error(`Oops! Failed to get token offers for id ${id}`);
+
+      const item = data.pop();
+      const { offers } = item;
+
+      if (!offers) throw Error('Oops! Offers not found!');
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      typeof onSuccess === 'function' && onSuccess();
+
+      thunkAPI.dispatch(marketplaceActions.setOffersLoaded(true));
+
+      return {
+        [id]: item,
+      };
+    } catch (err) {
+      AppLog.error(err);
+      thunkAPI.dispatch(
+        notificationActions.setErrorMessage(
+          `Oops! Failed to get token offers`,
+        ),
+      );
+      if (typeof onFailure === 'function') {
+        onFailure(err);
+      }
+
+      return {
+        [id]: {},
+      };
+    }
+  },
+);

--- a/src/store/features/marketplace/async-thunks/get-nft-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-nft-offers.ts
@@ -8,6 +8,9 @@ import {
 import { notificationActions } from '../../notifications';
 import { AppLog } from '../../../../utils/log';
 
+// TODO: delete getTokenOffers thunk when getNFTOffers is ready
+// to render NFT offers list
+
 export const getNFTOffers = createAsyncThunk<any | undefined, any>(
   'marketplace/getNFTOffers',
   async ({ collectionId, id, onSuccess, onFailure }, thunkAPI) => {
@@ -53,9 +56,9 @@ export const getNFTOffers = createAsyncThunk<any | undefined, any>(
 
       thunkAPI.dispatch(marketplaceActions.setOffersLoaded(true));
 
-      return {
-        [id]: item,
-      };
+      // TODO: parse NFT offers response
+
+      return offers;
     } catch (err) {
       AppLog.error(err);
       thunkAPI.dispatch(
@@ -67,9 +70,7 @@ export const getNFTOffers = createAsyncThunk<any | undefined, any>(
         onFailure(err);
       }
 
-      return {
-        [id]: {},
-      };
+      return [];
     }
   },
 );

--- a/src/store/features/marketplace/async-thunks/index.ts
+++ b/src/store/features/marketplace/async-thunks/index.ts
@@ -11,3 +11,4 @@ export * from './get-floor-price';
 export * from './get-collections';
 export * from './get-assets-to-withdraw';
 export * from './withdraw-fungible';
+export * from './get-nft-offers';

--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -1,4 +1,3 @@
-import { Principal } from '@dfinity/principal';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 import { notificationActions } from '../../notifications';

--- a/src/store/features/marketplace/marketplace-slice.ts
+++ b/src/store/features/marketplace/marketplace-slice.ts
@@ -96,6 +96,8 @@ type InitialState = {
   transactionSteps: TransactionStepsStatus;
   // TODO: jelly-js type
   jellyJsInstance: any;
+  // TODO: NFT offers type
+  nftOffers: any;
 };
 
 const defaultTransactionStatus = {
@@ -121,6 +123,7 @@ const initialState: InitialState = {
   offersLoaded: false,
   transactionSteps: defaultTransactionStatus,
   jellyJsInstance: {},
+  nftOffers: [],
 };
 
 export const marketplaceSlice = createSlice({
@@ -213,6 +216,11 @@ export const marketplaceSlice = createSlice({
       if (!action.payload) return;
 
       state.recentlyWithdrawnAssets.push(action.payload);
+    });
+    builder.addCase(getNFTOffers.fulfilled, (state, action) => {
+      if (!action.payload) return;
+
+      state.nftOffers = action.payload;
     });
   },
 });

--- a/src/store/features/marketplace/marketplace-slice.ts
+++ b/src/store/features/marketplace/marketplace-slice.ts
@@ -23,6 +23,7 @@ import {
   getCollections,
   getAssetsToWithdraw,
   withdrawFungible,
+  getNFTOffers,
 } from './async-thunks';
 import { TransactionStatus } from '../../../constants/transaction-status';
 
@@ -231,6 +232,7 @@ export const marketplaceActions = {
   getCollections,
   getAssetsToWithdraw,
   withdrawFungible,
+  getNFTOffers,
 };
 
 export default marketplaceSlice.reducer;


### PR DESCRIPTION
## Why?

Enable edit offer integration using jelly js

## How?

- [x] add NFT Offers thunk
- [x] fetch and store NFT offers in marketplace slice
- [x] update `userMadeOffer` logic in NFT details accordion component to show action buttons

## Tickets?

- [issue-504([the-ticket-url-here](https://github.com/Psychedelic/nft-marketplace-fe/issues/504))


## Demo?


https://user-images.githubusercontent.com/40259256/189328685-a2a4992b-6dd8-4bf5-8820-298c051e7308.mov


