### PR TITLE
fix: 🐛 show last page data on total page count

### DIFF
--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -104,12 +104,12 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
         loadedNFTList: extractedNFTSList,
         totalPages: Math.ceil(Number(total) / count),
         total,
-        nextPage:
-          Math.floor(Number(total) / Number(responseLastIndex)) + 1,
       };
 
       if (responseLastIndex) {
         actionPayload.lastIndex = Number(responseLastIndex) - 1;
+        actionPayload.nextPage =
+          Math.floor(Number(total) / Number(responseLastIndex)) + 1;
       }
 
       // update store with loaded NFTS details
@@ -138,3 +138,4 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
     }
   },
 );
+

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -45,7 +45,7 @@ export interface LoadedNFTData {
   loadedNFTList: NFTMetadata[];
   totalPages: number;
   total: number;
-  nextPage: number;
+  nextPage?: number;
   lastIndex?: number;
 }
 
@@ -98,6 +98,7 @@ export const nftsSlice = createSlice({
     setLoadedNFTS: (state, action: PayloadAction<LoadedNFTData>) => {
       const { loadedNFTList, totalPages, nextPage, lastIndex } =
         action.payload;
+
       state.loadingNFTs = false;
       state.lastIndexValue = Number(lastIndex);
       if (nextPage === 1) {
@@ -105,7 +106,7 @@ export const nftsSlice = createSlice({
       } else {
         state.loadedNFTS.push(...loadedNFTList);
       }
-      if (nextPage < totalPages) {
+      if (nextPage && nextPage <= totalPages) {
         state.hasMoreNFTs = true;
         state.nextPageNo = nextPage;
       } else {


### PR DESCRIPTION
## Why?

Before was not showing the last data set of last page, as it should trigger next page on last page match to display it.

## Demo?

<img width="1371" alt="Screenshot 2022-09-09 at 12 54 54" src="https://user-images.githubusercontent.com/236752/189344343-fe1ebeb2-1a3a-4e07-ae95-186ad7331222.png">
