### PR TITLE
fix: 🐛 use last index as cursor not total pages

### DIFF
--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -23,6 +23,8 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
       sort,
       reverse,
       // order,
+      // TODO: what's passed as page is the index
+      // as such it should be refactored, renamed to avoid confusion
       page,
       count,
       collectionId,
@@ -102,7 +104,8 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
 
       const actionPayload: LoadedNFTData = {
         loadedNFTList: extractedNFTSList,
-        totalPages: Math.ceil(Number(total) / count),
+        // TODO: refactor the concept of page and total pages
+        // totalPages: Math.ceil(Number(total) / count),
         total,
       };
 

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -43,7 +43,7 @@ const initialState: NFTSState = {
 
 export interface LoadedNFTData {
   loadedNFTList: NFTMetadata[];
-  totalPages: number;
+  totalPages?: number;
   total: number;
   nextPage?: number;
   lastIndex?: number;
@@ -96,17 +96,14 @@ export const nftsSlice = createSlice({
       }
     },
     setLoadedNFTS: (state, action: PayloadAction<LoadedNFTData>) => {
-      const { loadedNFTList, totalPages, nextPage, lastIndex } =
-        action.payload;
+      const { loadedNFTList, nextPage, lastIndex } = action.payload;
 
       state.loadingNFTs = false;
       state.lastIndexValue = Number(lastIndex);
-      if (nextPage === 1) {
-        state.loadedNFTS = loadedNFTList;
-      } else {
-        state.loadedNFTS.push(...loadedNFTList);
-      }
-      if (nextPage && nextPage <= totalPages) {
+
+      state.loadedNFTS.push(...loadedNFTList);
+
+      if (nextPage) {
         state.hasMoreNFTs = true;
         state.nextPageNo = nextPage;
       } else {


### PR DESCRIPTION
## Why?

The total pages should be deprecated or refactored considering the latest pagination changes in the service side.

## Demo?


https://user-images.githubusercontent.com/236752/189688170-96c4f3d3-1382-442c-8cf0-68db1118dae3.mp4

