### PR TITLE
fix: 🐛 traits missing field causes nft details to break

### DIFF
--- a/src/components/nft-details/nft-details.tsx
+++ b/src/components/nft-details/nft-details.tsx
@@ -171,10 +171,13 @@ export const NftDetails = () => {
                       name={nftDetails?.traits[`${key}`].name}
                       rimValue={`${
                         nftDetails?.traits[`${key}`].occurance
-                      } (${roundOffDecimalValue(
-                        nftDetails?.traits[`${key}`].rarity,
-                        2,
-                      )}%)`}
+                      } (${
+                        nftDetails?.traits[`${key}`].rarity &&
+                        roundOffDecimalValue(
+                          nftDetails?.traits[`${key}`].rarity,
+                          2,
+                        )
+                      }%)`}
                     />
                   ))}
                 </>


### PR DESCRIPTION
## Why?

Traits causing the details page to break, see screenshot.

## Demo?

<img width="618" alt="Screenshot 2022-09-13 at 13 12 15" src="https://user-images.githubusercontent.com/236752/189897771-a5c4e558-fa25-435d-b536-df2072588b55.png">
