### PR TITLE
feat: 🎸 show NFT offers using jelly js

### DIFF
--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -394,8 +394,8 @@ export const OfferAccordion = ({
 
   const { isConnected, principalId: plugPrincipal } = usePlugStore();
 
-  const tokenOffers = useSelector(
-    (state: RootState) => state.marketplace.tokenOffers,
+  const nftOffers = useSelector(
+    (state: RootState) => state.marketplace.nftOffers,
   );
 
   const isOwner = isNFTOwner({
@@ -434,7 +434,7 @@ export const OfferAccordion = ({
               <Icon icon="offer" paddingRight />
               <p>
                 {`${t('translation:accordions.offer.header.offer')}`}
-                <ItemCount>{`(${tokenOffers.length})`}</ItemCount>
+                <ItemCount>{`(${nftOffers.length})`}</ItemCount>
               </p>
             </div>
             <Icon icon="chevron-up" rotate={isAccordionOpen} />

--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -220,7 +220,7 @@ export const OfferAccordionHeader = ({
   isMobileScreen,
 }: OfferAccordionHeaderProps) => {
   const { t } = useTranslation();
-  const { id } = useParams();
+  const { id, collectionId } = useParams();
   const dispatch = useAppDispatch();
   const [loadingOffers, setLoadingOffers] = useState<boolean>(true);
 
@@ -234,22 +234,23 @@ export const OfferAccordionHeader = ({
     string | undefined
   >();
 
-  const tokenOffers = useSelector(
-    (state: RootState) => state.marketplace.tokenOffers,
+  const nftOffers = useSelector(
+    (state: RootState) => state.marketplace.nftOffers,
   );
 
   const topOffer: OffersTableItem = useMemo(
-    () => tokenOffers && tokenOffers[0],
-    [tokenOffers],
+    () => nftOffers && nftOffers[0],
+    [nftOffers],
   );
 
   useEffect(() => {
     // TODO: handle the error gracefully when there is no id
-    if (!isTokenId(id)) return;
+    if (!id || !collectionId) return;
 
     dispatch(
-      marketplaceActions.getTokenOffers({
-        ownerTokenIdentifiers: [BigInt(id as string)],
+      marketplaceActions.getNFTOffers({
+        id,
+        collectionId,
 
         onSuccess: () => {
           setLoadingOffers(false);

--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -110,13 +110,12 @@ export const OnConnected = ({
     (state: RootState) => state.marketplace.nftOffers,
   );
 
-  // TODO: offers Item type
-  const userMadeOffer: any = useMemo(
+  const userMadeOffer: OffersTableItem = useMemo(
     () =>
       nftOffers.find(
-        (offer: any) =>
-          offer?.buyer.toString() === plugPrincipalId &&
-          offer?.tokenId === id,
+        (offer: OffersTableItem) =>
+          offer?.fromDetails?.address === plugPrincipalId &&
+          offer?.item?.tokenId.toString() === id,
       ),
     [id, nftOffers, plugPrincipalId],
   );
@@ -193,7 +192,10 @@ export const OnConnected = ({
             showNonOwnerButtons && !loadingOffers && userMadeOffer,
           )}
         >
-          <CancelOfferModal item={userMadeOffer} largeTriggerButton />
+          <CancelOfferModal
+            item={userMadeOffer?.item}
+            largeTriggerButton
+          />
         </ButtonDetailsWrapper>
       )}
     </ButtonListWrapper>

--- a/src/components/modals/accept-offer-modal.tsx
+++ b/src/components/modals/accept-offer-modal.tsx
@@ -74,7 +74,7 @@ export const AcceptOfferModal = ({
 }: AcceptOfferProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const { id } = useParams();
+  const { id, collectionId } = useParams();
   const { loadedNFTS } = useNFTSStore();
 
   const [modalOpened, setModalOpened] = useState<boolean>(false);
@@ -118,13 +118,14 @@ export const AcceptOfferModal = ({
   };
 
   const handleAcceptOffer = async () => {
-    if (!isTokenId(tokenId)) return;
+    if (!isTokenId(tokenId) || !collectionId) return;
 
     setModalStep(ListingStatusCodes.Pending);
 
     dispatch(
       marketplaceActions.acceptOffer({
         id: tokenId as string,
+        collectionId,
         buyerPrincipalId: offerFrom,
         offerPrice: price,
         onSuccess: () => {

--- a/src/components/tables/nft-offers-table.tsx
+++ b/src/components/tables/nft-offers-table.tsx
@@ -11,17 +11,12 @@ import {
 import { PriceDetailsCell, TextCell, TextLinkCell } from '../core';
 import { AcceptOfferModal } from '../modals';
 import { TableLayout } from './table-layout';
-import {
-  Container,
-  ButtonWrapper,
-  EmptyStateMessage,
-} from './styles';
+import { Container, ButtonWrapper } from './styles';
 import { OffersTableItem } from '../../declarations/legacy';
 import {
   formatPriceValue,
   parseE8SAmountToWICP,
 } from '../../utils/formatters';
-import { isTokenId } from '../../utils/nfts';
 import { isNFTOwner } from '../../integrations/kyasshu/utils';
 import { formatTimestamp } from '../../integrations/functions/date';
 import { getICAccountLink } from '../../utils/account-id';
@@ -67,11 +62,11 @@ export const NFTOffersTable = ({
     (state: RootState) => state.marketplace.recentlyCancelledOffers,
   );
 
-  const tokenOffers = useSelector(
-    (state: RootState) => state.marketplace.tokenOffers,
+  const nftOffers = useSelector(
+    (state: RootState) => state.marketplace.nftOffers,
   );
 
-  const { id: tokenId } = useParams();
+  const { id, collectionId } = useParams();
 
   const { isConnected, principalId: plugPrincipal } = usePlugStore();
 
@@ -94,12 +89,16 @@ export const NFTOffersTable = ({
   }, [isConnectedOwner]);
 
   useEffect(() => {
-    if (!isTokenId(tokenId)) return;
+    if (!id || !collectionId) return;
 
     dispatch(
-      marketplaceActions.getTokenOffers({
-        // TODO: update ownerTokenIdentifiers naming convention
-        ownerTokenIdentifiers: [BigInt(tokenId as string)],
+      marketplaceActions.getNFTOffers({
+        id,
+        collectionId,
+
+        onSuccess: () => {
+          // TODO: handle success messages
+        },
 
         onFailure: () => {
           // TODO: handle failure messages
@@ -116,9 +115,9 @@ export const NFTOffersTable = ({
   useEffect(() => {
     setTableDetails({
       loading: false,
-      loadedOffers: tokenOffers,
+      loadedOffers: nftOffers,
     });
-  }, [tokenOffers]);
+  }, [nftOffers]);
 
   const columns = useMemo(
     () => [

--- a/src/declarations/marketplace-v2.d.ts
+++ b/src/declarations/marketplace-v2.d.ts
@@ -78,7 +78,7 @@ export type ListingStatus =
 export type NFTStandard = { DIP721v2: null };
 export interface Offer {
   status: OfferStatus;
-  token_id: string;
+  tokenId: string;
   time: bigint;
   fungible_id: Principal;
   token_owner: Principal;
@@ -168,4 +168,3 @@ export interface _SERVICE {
 }
 
 export default _SERVICE;
-

--- a/src/declarations/marketplace-v2.d.ts
+++ b/src/declarations/marketplace-v2.d.ts
@@ -78,7 +78,7 @@ export type ListingStatus =
 export type NFTStandard = { DIP721v2: null };
 export interface Offer {
   status: OfferStatus;
-  tokenId: string;
+  token_id: string;
   time: bigint;
   fungible_id: Principal;
   token_owner: Principal;

--- a/src/store/features/marketplace/async-thunks/get-nft-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-nft-offers.ts
@@ -7,6 +7,7 @@ import {
 } from '../marketplace-slice';
 import { notificationActions } from '../../notifications';
 import { AppLog } from '../../../../utils/log';
+import { parseNFTOffers } from '../../../../utils/parser';
 
 // TODO: delete getTokenOffers thunk when getNFTOffers is ready
 // to render NFT offers list
@@ -51,14 +52,22 @@ export const getNFTOffers = createAsyncThunk<any | undefined, any>(
 
       if (!offers) throw Error('Oops! Offers not found!');
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      // TODO: get floor price and calculate floor difference
+
+      // TODO: get ICP Price
+
+      const parsedNFTOffers =
+        !Array.isArray(offers) || !offers.length
+          ? []
+          : parseNFTOffers({
+              offers,
+            });
+
       typeof onSuccess === 'function' && onSuccess();
 
       thunkAPI.dispatch(marketplaceActions.setOffersLoaded(true));
 
-      // TODO: parse NFT offers response
-
-      return offers;
+      return parsedNFTOffers;
     } catch (err) {
       AppLog.error(err);
       thunkAPI.dispatch(

--- a/src/store/features/marketplace/async-thunks/get-nft-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-nft-offers.ts
@@ -8,6 +8,7 @@ import {
 import { notificationActions } from '../../notifications';
 import { AppLog } from '../../../../utils/log';
 import { parseNFTOffers } from '../../../../utils/parser';
+import { getICPPrice } from '../../../../integrations/marketplace/price.utils';
 
 // TODO: delete getTokenOffers thunk when getNFTOffers is ready
 // to render NFT offers list
@@ -38,6 +39,7 @@ export const getNFTOffers = createAsyncThunk<any | undefined, any>(
     thunkAPI.dispatch(marketplaceActions.setOffersLoaded(false));
 
     try {
+      let currencyMarketPrice;
       const result = await jellyCollection.getNFTs({
         ids: [id],
       });
@@ -54,13 +56,18 @@ export const getNFTOffers = createAsyncThunk<any | undefined, any>(
 
       // TODO: get floor price and calculate floor difference
 
-      // TODO: get ICP Price
+      // Fetch ICP Price
+      const icpPriceResponse = await getICPPrice();
+      if (icpPriceResponse && icpPriceResponse.usd) {
+        currencyMarketPrice = icpPriceResponse.usd;
+      }
 
       const parsedNFTOffers =
         !Array.isArray(offers) || !offers.length
           ? []
           : parseNFTOffers({
               offers,
+              currencyMarketPrice,
             });
 
       typeof onSuccess === 'function' && onSuccess();

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { Principal } from '@dfinity/principal';
+import { Offer as NFTOffer } from '@psychedelic/jelly-js';
 import { Listing, Offer } from '../declarations/marketplace';
 import {
   formatAddress,
@@ -14,7 +15,6 @@ import {
 } from './sorting';
 import { OperationTypes, OperationType } from '../constants';
 import { checkIfDirectContractEvent } from './nfts';
-import { Offer as NFTOffer } from '../declarations/marketplace-v2';
 
 type GetAllListingsDataResponse = Array<
   [[Principal, bigint], Listing]

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -14,6 +14,7 @@ import {
 } from './sorting';
 import { OperationTypes, OperationType } from '../constants';
 import { checkIfDirectContractEvent } from './nfts';
+import { Offer as NFTOffer } from '../declarations/marketplace-v2';
 
 type GetAllListingsDataResponse = Array<
   [[Principal, bigint], Listing]
@@ -347,6 +348,50 @@ export const parseBalanceResponse = (data: Array<any>) => {
 
     return [...accParent, assetsToWithdraw];
   }, [] as AssetsToWithdraw);
+
+  return parsed;
+};
+
+interface ParseNFTOffersParams {
+  offers: Array<NFTOffer>;
+}
+
+export type ParsedNFTOffers = OffersTableItem[];
+
+export const parseNFTOffers = ({ offers }: ParseNFTOffersParams) => {
+  const parsed = offers.reduce((accParent, currParent) => {
+    const {
+      price,
+      tokenId: token_id,
+      buyer: paymentAddress,
+      time: created,
+    } = currParent;
+
+    // TODO: What to do if payment address not valid principal?
+    const fromDetails = {
+      formattedAddress: paymentAddress._isPrincipal
+        ? formatAddress(paymentAddress.toString())
+        : 'n/a',
+      address: paymentAddress._isPrincipal
+        ? paymentAddress.toString()
+        : 'n/a',
+    };
+
+    const offerTableItem: OffersTableItem = {
+      item: {
+        // TODO: formatter for name, as number should probably have leading 0's
+        // e.g. Cap Crowns #00001 ?!
+        name: `CAP Crowns #${token_id}`,
+        tokenId: BigInt(token_id),
+      },
+      price,
+      floorDifference: 'n/a',
+      fromDetails,
+      time: created.toString(),
+    };
+
+    return [...accParent, offerTableItem];
+  }, [] as ParsedNFTOffers);
 
   return parsed;
 };

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -354,11 +354,15 @@ export const parseBalanceResponse = (data: Array<any>) => {
 
 interface ParseNFTOffersParams {
   offers: Array<NFTOffer>;
+  currencyMarketPrice?: number;
 }
 
 export type ParsedNFTOffers = OffersTableItem[];
 
-export const parseNFTOffers = ({ offers }: ParseNFTOffersParams) => {
+export const parseNFTOffers = ({
+  offers,
+  currencyMarketPrice,
+}: ParseNFTOffersParams) => {
   const parsed = offers.reduce((accParent, currParent) => {
     const {
       price,
@@ -377,6 +381,10 @@ export const parseNFTOffers = ({ offers }: ParseNFTOffersParams) => {
         : 'n/a',
     };
 
+    const computedCurrencyPrice =
+      currencyMarketPrice &&
+      currencyMarketPrice * Number(parseE8SAmountToWICP(price));
+
     const offerTableItem: OffersTableItem = {
       item: {
         // TODO: formatter for name, as number should probably have leading 0's
@@ -388,6 +396,7 @@ export const parseNFTOffers = ({ offers }: ParseNFTOffersParams) => {
       floorDifference: 'n/a',
       fromDetails,
       time: created.toString(),
+      computedCurrencyPrice,
     };
 
     return [...accParent, offerTableItem];


### PR DESCRIPTION
## Why?

Show NFT offers using `jelly js`

## How?

- [x] create parser to generate NFT offers table data from NFT offers fetched from `jelly js`
- [x] use updated parser in `getNFTOffers` thunk
- [x] use updated `NFTOffers` data in NFT offers table
- [x] use updated `NFTOffers` data in accordion to show total offers count

## Tickets?

- [Issue 536](https://github.com/Psychedelic/nft-marketplace-fe/issues/536)

## Demo?


https://user-images.githubusercontent.com/40259256/189945019-1aa9de64-09bc-465b-be06-7463cd6983b2.mov


