### PR TITLE
feat: 🎸  buy now integration using jelly-js

### DIFF
--- a/src/components/collection-overview/collection-overview.tsx
+++ b/src/components/collection-overview/collection-overview.tsx
@@ -1,11 +1,13 @@
 import copyToClipboard from 'copy-to-clipboard';
 import { useTranslation } from 'react-i18next';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import {
   notificationActions,
   useAppDispatch,
   useNFTSStore,
   useTableStore,
+  marketplaceActions,
 } from '../../store';
 import { FilteredCountChip, LinkButton } from '../core';
 import {
@@ -34,6 +36,8 @@ export const CollectionOverview = () => {
   const dispatch = useAppDispatch();
   const [theme] = useTheme();
 
+  const { id, collectionId } = useParams();
+
   const { loadingTableData } = useTableStore();
   const {
     loadingNFTs,
@@ -49,6 +53,17 @@ export const CollectionOverview = () => {
     () => loadingTableData || loadingNFTs || loadingCollectionData,
     [loadingTableData, loadingNFTs, loadingCollectionData],
   );
+
+  useEffect(() => {
+    if (!collectionId) return;
+
+    dispatch(
+      marketplaceActions.getCollectionDetails({ collectionId }),
+    );
+
+    // TODO: Update static data like crowns title, icon
+    // by using currentCollectionDetails state
+  }, [id, collectionId]);
 
   return (
     <NftMetadataWrapper>

--- a/src/components/core/accordions/offer-accordion.tsx
+++ b/src/components/core/accordions/offer-accordion.tsx
@@ -120,6 +120,10 @@ export const OnConnected = ({
     [id, nftOffers, plugPrincipalId],
   );
 
+  const collectionDetails = useSelector(
+    (state: RootState) => state.marketplace.currentCollectionDetails,
+  );
+
   useEffect(() => {
     // TODO: handle the error gracefully when there is no id
     if (!id || !collectionId || !plugPrincipalId) return;
@@ -157,7 +161,10 @@ export const OnConnected = ({
         <BuyNowModal
           price={price?.toString()}
           isTriggerVisible={showNonOwnerButtons && isListed}
-          isNFTOperatedByMKP={isOperatorMarketplace({ operator })}
+          isNFTOperatedByMKP={isOperatorMarketplace({
+            operator,
+            marketplaceId: collectionDetails?.marketplaceId,
+          })}
         />
       </ButtonDetailsWrapper>
       <ButtonDetailsWrapper

--- a/src/components/core/cards/nft-card/nft-card.tsx
+++ b/src/components/core/cards/nft-card/nft-card.tsx
@@ -25,7 +25,10 @@ import {
   SellModal,
   ChangePriceModal,
 } from '../../../modals';
-import { usePlugStore } from '../../../../store';
+import {
+  usePlugStore,
+  CurrentCollectionDetails,
+} from '../../../../store';
 import { parseE8SAmountToWICP } from '../../../../utils/formatters';
 import { NFTActionStatuses } from '../../../../constants/common';
 import { NumberTooltip } from '../../../number-tooltip';
@@ -39,6 +42,7 @@ export type NftCardProps = {
   data: any;
   previewCard?: boolean;
   previewCardAmount?: string | number;
+  collectionDetails?: CurrentCollectionDetails;
 };
 
 type ConnectedProps = {
@@ -47,6 +51,7 @@ type ConnectedProps = {
   tokenId: string;
   price?: bigint;
   operator?: string;
+  marketplaceId?: string;
 };
 
 type DisconnectedProps = {
@@ -65,6 +70,7 @@ const OnConnected = ({
   tokenId,
   price,
   operator,
+  marketplaceId,
 }: ConnectedProps) => {
   const { t } = useTranslation();
   const showBuyerOptions = !owned;
@@ -97,7 +103,10 @@ const OnConnected = ({
               (price && parseE8SAmountToWICP(BigInt(price))) || ''
             }
             isTriggerVisible={isForSale}
-            isNFTOperatedByMKP={isOperatorMarketplace({ operator })}
+            isNFTOperatedByMKP={isOperatorMarketplace({
+              operator,
+              marketplaceId,
+            })}
           />
           <MakeOfferModal
             actionText={`${t('translation:nftCard.forOffer')}`}
@@ -182,6 +191,7 @@ export const NftCard = React.memo(
     data,
     previewCard = false,
     previewCardAmount,
+    collectionDetails,
   }: NftCardProps) => {
     const { t } = useTranslation();
     const { isConnected } = usePlugStore();
@@ -261,6 +271,7 @@ export const NftCard = React.memo(
                   tokenId={data.id}
                   price={data?.price}
                   operator={data?.operator}
+                  marketplaceId={collectionDetails?.marketplaceId}
                 />
               )) || <OnDisconnected isForSale={isForSale} />}
               <LastActionTakenDetails

--- a/src/components/nft-details/nft-details.tsx
+++ b/src/components/nft-details/nft-details.tsx
@@ -110,6 +110,10 @@ export const NftDetails = () => {
     // TODO: handle the error gracefully when there is no id
     if (!id || !collectionId) return;
 
+    dispatch(
+      marketplaceActions.getCollectionDetails({ collectionId }),
+    );
+
     if (!loadedFiltersList.length) {
       dispatch(filterActions.getFilterTraits({ collectionId }));
     }

--- a/src/components/nft-list/nft-list.tsx
+++ b/src/components/nft-list/nft-list.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import InfiniteScroll from 'react-infinite-scroller';
 import { NftCard } from '../core/cards/nft-card';
 import {
@@ -9,6 +10,7 @@ import {
   useAppDispatch,
   usePlugStore,
   nftsActions,
+  RootState,
 } from '../../store';
 import { EmptyState, NftSkeleton, VirtualizedGrid } from '../core';
 import { ButtonType } from '../../constants/empty-states';
@@ -36,6 +38,11 @@ export const NftList = () => {
   const { isMyNfts, status, defaultFilters, reverse } =
     useFilterStore();
   const { principalId, isConnected } = usePlugStore();
+
+  const collectionDetails = useSelector(
+    (state: RootState) => state.marketplace.currentCollectionDetails,
+  );
+
   const traitsPayload = useTraitsPayload();
 
   const priceValues = usePriceValues();
@@ -160,6 +167,7 @@ export const NftList = () => {
               owner: nft?.owner,
               principalId,
             })}
+            collectionDetails={collectionDetails}
           />
         ))}
         Skeleton={NftSkeleton}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -79,8 +79,10 @@ const config: Config = {
     kyasshuMarketplaceAPI: 'http://localhost:3000/local',
     icScan: 'https://icscan.io/principal',
     nftCollectionId: process.env.REACT_APP_CROWNS_ID as string,
-    marketplaceCanisterId: process.env
-      .REACT_APP_MARKETPLACE_ID as string,
+    // marketplaceCanisterId: process.env
+    //   .REACT_APP_MARKETPLACE_ID as string,
+    // TODO: update REACT_APP_MARKETPLACE_ID with correct Id in start script
+    marketplaceCanisterId: 'q4eej-kyaaa-aaaaa-aaaha-cai',
     wICPCanisterId: process.env.REACT_APP_WICP_ID as string,
     capRouterId: process.env.REACT_APP_CAP_ID as string,
   },

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -79,10 +79,8 @@ const config: Config = {
     kyasshuMarketplaceAPI: 'http://localhost:3000/local',
     icScan: 'https://icscan.io/principal',
     nftCollectionId: process.env.REACT_APP_CROWNS_ID as string,
-    // marketplaceCanisterId: process.env
-    //   .REACT_APP_MARKETPLACE_ID as string,
-    // TODO: update REACT_APP_MARKETPLACE_ID with correct Id in start script
-    marketplaceCanisterId: 'q4eej-kyaaa-aaaaa-aaaha-cai',
+    marketplaceCanisterId: process.env
+      .REACT_APP_MARKETPLACE_ID as string,
     wICPCanisterId: process.env.REACT_APP_WICP_ID as string,
     capRouterId: process.env.REACT_APP_CAP_ID as string,
   },

--- a/src/store/features/marketplace/async-thunks/get-collection-details.ts
+++ b/src/store/features/marketplace/async-thunks/get-collection-details.ts
@@ -1,0 +1,57 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
+import { getJellyCollection } from '../../../../utils/jelly';
+import {
+  marketplaceSlice,
+  CollectionDetails,
+} from '../marketplace-slice';
+import { notificationActions } from '../../notifications';
+import { AppLog } from '../../../../utils/log';
+
+type GetCollectionDetailsProps = CollectionDetails;
+
+export const getCollectionDetails = createAsyncThunk<
+  any | undefined,
+  GetCollectionDetailsProps
+>(
+  'marketplace/getCollectionDetails',
+  async ({ collectionId }, thunkAPI) => {
+    try {
+      // Checks if an actor instance exists already
+      // otherwise creates a new instance
+      const jellyInstance = await jellyJsInstanceHandler({
+        thunkAPI,
+        collectionId,
+        slice: marketplaceSlice,
+      });
+
+      const collection = await getJellyCollection({
+        jellyInstance,
+        collectionId,
+      });
+
+      if (!collection)
+        throw Error(`Oops! collection ${collectionId} not found!`);
+
+      if (!collection?.marketplaceId)
+        throw Error(
+          `Oops! marketplace id ${collection?.marketplaceId} not found!`,
+        );
+
+      const currentCollectionDetails = {
+        marketplaceId: collection.marketplaceId.toString(),
+      };
+
+      return currentCollectionDetails;
+    } catch (err) {
+      AppLog.error(err);
+      thunkAPI.dispatch(
+        notificationActions.setErrorMessage(
+          `Oops! Failed to get collection details`,
+        ),
+      );
+
+      return {};
+    }
+  },
+);

--- a/src/store/features/marketplace/async-thunks/index.ts
+++ b/src/store/features/marketplace/async-thunks/index.ts
@@ -13,3 +13,4 @@ export * from './get-assets-to-withdraw';
 export * from './withdraw-fungible';
 export * from './get-nft-offers';
 export * from './get-user-offers';
+export * from './get-collection-details';

--- a/src/store/features/marketplace/marketplace-slice.ts
+++ b/src/store/features/marketplace/marketplace-slice.ts
@@ -26,6 +26,7 @@ import {
   withdrawFungible,
   getNFTOffers,
   getUserOffers,
+  getCollectionDetails,
 } from './async-thunks';
 import { TransactionStatus } from '../../../constants/transaction-status';
 
@@ -71,6 +72,10 @@ export type CollectionDetails = {
   collectionId: string;
 };
 
+export type CurrentCollectionDetails = {
+  marketplaceId?: string;
+};
+
 type RecentyListedForSale = MakeListing[];
 
 type MarketplaceActor = ActorSubclass<marketplaceIdlService>;
@@ -101,6 +106,7 @@ type InitialState = {
   jellyJsInstance?: JellyUtils;
   // TODO: NFT offers type
   nftOffers: any;
+  currentCollectionDetails: CurrentCollectionDetails;
 };
 
 const defaultTransactionStatus = {
@@ -128,6 +134,7 @@ const initialState: InitialState = {
   transactionSteps: defaultTransactionStatus,
   jellyJsInstance: undefined,
   nftOffers: [],
+  currentCollectionDetails: {},
 };
 
 export const marketplaceSlice = createSlice({
@@ -231,6 +238,14 @@ export const marketplaceSlice = createSlice({
 
       state.nftOffers = action.payload;
     });
+    builder.addCase(
+      getCollectionDetails.fulfilled,
+      (state, action) => {
+        if (!action.payload) return;
+
+        state.currentCollectionDetails = action.payload;
+      },
+    );
   },
 });
 
@@ -251,6 +266,7 @@ export const marketplaceActions = {
   withdrawFungible,
   getNFTOffers,
   getUserOffers,
+  getCollectionDetails,
 };
 
 export default marketplaceSlice.reducer;

--- a/src/utils/nfts.ts
+++ b/src/utils/nfts.ts
@@ -59,8 +59,6 @@ export const isOperatorMarketplace = (
 ) => {
   const { operator, marketplaceId } = params;
 
-  console.log(marketplaceId, 'marketplaceId');
-
   if (!operator || !marketplaceId) return;
 
   return operator === marketplaceId;

--- a/src/utils/nfts.ts
+++ b/src/utils/nfts.ts
@@ -13,6 +13,7 @@ type NFTParams = {
 
 type CheckNFTOperatorParams = {
   operator?: string;
+  marketplaceId?: string;
 };
 
 export const findLastAction = (nft: NFTParams) => {
@@ -56,13 +57,16 @@ export const roundOffDecimalValue = (
 export const isOperatorMarketplace = (
   params: CheckNFTOperatorParams,
 ) => {
-  const { operator } = params;
+  const { operator, marketplaceId } = params;
 
-  return operator === config.marketplaceCanisterId;
+  console.log(marketplaceId, 'marketplaceId');
+
+  if (!operator || !marketplaceId) return;
+
+  return operator === marketplaceId;
 };
 
 const userRelevantDirectContractOps = ['mint', 'transfer'];
 export const checkIfDirectContractEvent = (
   operationType: OperationType,
 ) => userRelevantDirectContractOps.includes(operationType);
-


### PR DESCRIPTION
## Why?

Update buy now integration using jelly-js

## How?

- [x] update `direct-buy` thunk with `jelly-js` integration
- [x] update `isOperatorMarketplace` logic 
- [x] add `getCollectionDetails` thunk to fetch collection details like marketplaceId and pass it to `isOperatorMarketplace` logic to check `buy now` button should be disabled or not

## Tickets?

- [Issue 555](https://github.com/Psychedelic/nft-marketplace-fe/issues/555)

## Demo?


https://user-images.githubusercontent.com/40259256/191483291-9036b194-d668-4d45-a036-8e64cafc66ec.mov


