### PR TITLE
perf: ⚡ cache mock generator listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /build
 
 # misc
+.cache
 .DS_Store
 .env
 .env.local


### PR DESCRIPTION
## Why?

The crowns list output is pulled from remote, but the list does not change, as such would be nice to speed up the process by caching.

## Demo?

<img width="552" alt="Screenshot 2022-09-22 at 14 09 12" src="https://user-images.githubusercontent.com/236752/191755635-44b5e524-50d5-4a54-9129-0010f5478975.png">
