### PR TITLE
fix: 🐛 remove typo on list var

### DIFF
--- a/.scripts/generate-mocked-tokens-v2.sh
+++ b/.scripts/generate-mocked-tokens-v2.sh
@@ -177,8 +177,6 @@ printf "👍 Mint process completed!\n\n"
     touch "$cacheFilePath"
 
     getMetadata "$totalSupply" "$crownsCanisterId" | tee "$cacheFilePath"
-
-    echo "$list" > "$cacheFilePath"
   fi
 
   list=$(<"$cacheFilePath")


### PR DESCRIPTION
## Why?

Found a typo in the cache process, which caused the list to be blank.
