### PR TITLE
fix: 🐛 fixed pagination while loading all NFT's

### DIFF
--- a/src/components/nft-list/nft-list.tsx
+++ b/src/components/nft-list/nft-list.tsx
@@ -69,8 +69,7 @@ export const NftList = () => {
       loadingNFTs ||
       !hasMoreNFTs ||
       nextPageNo <= 0 ||
-      !collectionId ||
-      !isMyNfts
+      !collectionId
     )
       return;
 

--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -145,4 +145,3 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
     }
   },
 );
-


### PR DESCRIPTION
## Why?

Fix pagination while loading all NFT's

## How?

- [x] update load more NFTs logic to fix pagination 

## Tickets?

- [Issue 571](https://github.com/Psychedelic/nft-marketplace-fe/issues/571)

## Demo?


https://user-images.githubusercontent.com/40259256/192218572-faac898c-0a6f-4b5a-82c2-ce8d9cfaa6bc.mov


