### PR TITLE
refactor: 💡 remove collection id on jellyjs instance creation

### DIFF
--- a/src/integrations/jelly-js/jelly-js.utils.ts
+++ b/src/integrations/jelly-js/jelly-js.utils.ts
@@ -15,12 +15,10 @@ export const createJellyJsInstance = () => {
 // otherwise creates a new instance
 export const jellyJsInstanceHandler = async ({
   thunkAPI,
-  collectionId,
   slice,
 }: {
   // TODO: Where is GetThunkAPI typedef?
   thunkAPI: any;
-  collectionId: string;
   // Slice should have a `setJellyJsInstance` action
   slice: any;
 }) => {
@@ -28,9 +26,7 @@ export const jellyJsInstanceHandler = async ({
     thunkAPI.getState();
 
   if (!jellyJsInstance) {
-    AppLog.warn(
-      `Creating new Jelly-js instance for collection ${collectionId}`,
-    );
+    AppLog.warn('Creating new Jelly-js instance');
 
     // TODO: initialisation of jelly-js
     const newJellyJsInstance = createJellyJsInstance();

--- a/src/store/features/cap/async-thunks/get-token-contract-root-bucket.ts
+++ b/src/store/features/cap/async-thunks/get-token-contract-root-bucket.ts
@@ -23,7 +23,6 @@ export const getTokenContractRootBucket = createAsyncThunk<
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 

--- a/src/store/features/filters/async-thunks/get-filter-traits.ts
+++ b/src/store/features/filters/async-thunks/get-filter-traits.ts
@@ -62,7 +62,6 @@ export const getFilterTraits = createAsyncThunk<
 >('filters/getFilterTraits', async ({ collectionId }, thunkAPI) => {
   const jellyInstance = await jellyJsInstanceHandler({
     thunkAPI,
-    collectionId,
     slice: marketplaceSlice,
   });
 

--- a/src/store/features/marketplace/async-thunks/accept-offer.ts
+++ b/src/store/features/marketplace/async-thunks/accept-offer.ts
@@ -10,11 +10,9 @@ import {
 } from '../marketplace-slice';
 import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
 import { getJellyCollection } from '../../../../utils/jelly';
-import config from '../../../../config/env';
 import marketplaceV2IdlFactory from '../../../../declarations/marketplace-v2.did';
 import nftIdlFactory from '../../../../declarations/nft.did';
 import { AppLog } from '../../../../utils/log';
-import { parseAmountToE8S } from '../../../../utils/formatters';
 import { KyasshuUrl } from '../../../../integrations/kyasshu';
 import { errorMessageHandler } from '../../../../utils/error';
 import { TransactionStatus } from '../../../../constants/transaction-status';
@@ -44,7 +42,6 @@ export const acceptOffer = createAsyncThunk<
   // otherwise creates a new instance
   const jellyInstance = await jellyJsInstanceHandler({
     thunkAPI,
-    collectionId,
     slice: marketplaceSlice,
   });
 

--- a/src/store/features/marketplace/async-thunks/cancel-listing.ts
+++ b/src/store/features/marketplace/async-thunks/cancel-listing.ts
@@ -29,7 +29,6 @@ export const cancelListing = createAsyncThunk<
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId: collectionId.toString(),
       slice: marketplaceSlice,
     });
 

--- a/src/store/features/marketplace/async-thunks/cancel-offer.ts
+++ b/src/store/features/marketplace/async-thunks/cancel-offer.ts
@@ -28,7 +28,6 @@ export const cancelOffer = createAsyncThunk<
   // otherwise creates a new instance
   const jellyInstance = await jellyJsInstanceHandler({
     thunkAPI,
-    collectionId,
     slice: marketplaceSlice,
   });
 
@@ -106,3 +105,4 @@ export const cancelOffer = createAsyncThunk<
     }
   }
 });
+

--- a/src/store/features/marketplace/async-thunks/direct-buy.ts
+++ b/src/store/features/marketplace/async-thunks/direct-buy.ts
@@ -42,7 +42,6 @@ export const directBuy = createAsyncThunk<
   // otherwise creates a new instance
   const jellyInstance = await jellyJsInstanceHandler({
     thunkAPI,
-    collectionId,
     slice: marketplaceSlice,
   });
 

--- a/src/store/features/marketplace/async-thunks/get-all-collections.ts
+++ b/src/store/features/marketplace/async-thunks/get-all-collections.ts
@@ -1,35 +1,32 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { Collection } from '@psychedelic/jelly-js';
 import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
 import {
   marketplaceActions,
   marketplaceSlice,
 } from '../marketplace-slice';
 import { AppLog } from '../../../../utils/log';
-import { Collection } from '@psychedelic/jelly-js';
 
-export const getAllCollections = createAsyncThunk<
-  any | undefined,
-  any
->(
+export const getAllCollections = createAsyncThunk<any>(
   'marketplace/getCollections',
-  async ({ collectionId }, thunkAPI) => {
+  async (_params, thunkAPI) => {
     // Checks if an actor instance exists already
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 
     const { dispatch } = thunkAPI;
 
     try {
-      const jellyCollection: Collection[] =
+      const collections: Collection[] =
         await jellyInstance.getCollections();
 
-      dispatch(marketplaceActions.setCollections(jellyCollection));
+      dispatch(marketplaceActions.setCollections(collections));
     } catch (err) {
       AppLog.error(err);
     }
   },
 );
+

--- a/src/store/features/marketplace/async-thunks/get-buyer-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-buyer-offers.ts
@@ -11,11 +11,6 @@ import { notificationActions } from '../../notifications';
 import { parseOffersMadeResponse } from '../../../../utils/parser';
 import { OffersTableItem } from '../../../../declarations/legacy';
 import { AppLog } from '../../../../utils/log';
-import {
-  floorDiffPercentageCalculator,
-  formatAddress,
-  parseE8SAmountToWICP,
-} from '../../../../utils/formatters';
 import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
 import { getJellyCollection } from '../../../../utils/jelly';
 import { getPrincipal } from '../../../../integrations/plug';
@@ -38,7 +33,6 @@ export const getBuyerOffers = createAsyncThunk<
 
   const jellyInstance = await jellyJsInstanceHandler({
     thunkAPI,
-    collectionId,
     slice: marketplaceSlice,
   });
 

--- a/src/store/features/marketplace/async-thunks/get-collection-details.ts
+++ b/src/store/features/marketplace/async-thunks/get-collection-details.ts
@@ -21,7 +21,6 @@ export const getCollectionDetails = createAsyncThunk<
       // otherwise creates a new instance
       const jellyInstance = await jellyJsInstanceHandler({
         thunkAPI,
-        collectionId,
         slice: marketplaceSlice,
       });
 
@@ -55,3 +54,4 @@ export const getCollectionDetails = createAsyncThunk<
     }
   },
 );
+

--- a/src/store/features/marketplace/async-thunks/get-nft-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-nft-offers.ts
@@ -21,7 +21,6 @@ export const getNFTOffers = createAsyncThunk<any | undefined, any>(
     // otherwise creates a new instance
     const jellyInstance: JellyUtils = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId: collectionId.toString(),
       slice: marketplaceSlice,
     });
 
@@ -99,3 +98,4 @@ export const getNFTOffers = createAsyncThunk<any | undefined, any>(
     }
   },
 );
+

--- a/src/store/features/marketplace/async-thunks/get-token-listing.ts
+++ b/src/store/features/marketplace/async-thunks/get-token-listing.ts
@@ -11,7 +11,6 @@ export const getTokenListing = createAsyncThunk<any | undefined, any>(
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId: collectionId.toString(),
       slice: marketplaceSlice,
     });
 

--- a/src/store/features/marketplace/async-thunks/get-user-offers.ts
+++ b/src/store/features/marketplace/async-thunks/get-user-offers.ts
@@ -1,4 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { Principal } from '@dfinity/principal';
+import { NFTToken, Offer } from '@psychedelic/jelly-js';
 import { jellyJsInstanceHandler } from '../../../../integrations/jelly-js';
 import {
   marketplaceActions,
@@ -15,10 +17,7 @@ import {
   parseE8SAmountToWICP,
 } from '../../../../utils/formatters';
 import { actorInstanceHandler } from '../../../../integrations/actor';
-import { Principal } from '@dfinity/principal';
 import config from '../../../../config/env';
-import { getICPPrice } from '../../../../integrations/marketplace/price.utils';
-import { NFTToken, Offer } from '@psychedelic/jelly-js';
 
 export type GetUserNFTsProps = NSKyasshuUrl.GetNFTsQueryParams & {
   payload?: any;
@@ -41,7 +40,6 @@ export const getUserOffers = createAsyncThunk<any | undefined, any>(
 
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 
@@ -82,17 +80,14 @@ export const getUserOffers = createAsyncThunk<any | undefined, any>(
         const metadata = item.offers.reduce(
           (
             acc: any,
-            {
-              price,
-              tokenId: tokenId,
-              buyer: paymentAddress,
-              time,
-            }: Offer,
+            { price, tokenId, buyer: paymentAddress, time }: Offer,
           ) => {
             const fromDetails = {
+              // eslint-disable-next-line no-underscore-dangle
               formattedAddress: paymentAddress._isPrincipal
                 ? formatAddress(paymentAddress.toString())
                 : 'n/a',
+              // eslint-disable-next-line no-underscore-dangle
               address: paymentAddress._isPrincipal
                 ? paymentAddress.toString()
                 : 'n/a',
@@ -146,3 +141,4 @@ export const getUserOffers = createAsyncThunk<any | undefined, any>(
     }
   },
 );
+

--- a/src/store/features/marketplace/async-thunks/make-listing.ts
+++ b/src/store/features/marketplace/async-thunks/make-listing.ts
@@ -36,7 +36,6 @@ export const makeListing = createAsyncThunk<
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 

--- a/src/store/features/marketplace/async-thunks/make-offer.ts
+++ b/src/store/features/marketplace/async-thunks/make-offer.ts
@@ -34,7 +34,6 @@ export const makeOffer = createAsyncThunk<
   // otherwise creates a new instance
   const jellyInstance = await jellyJsInstanceHandler({
     thunkAPI,
-    collectionId,
     slice: marketplaceSlice,
   });
 

--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -35,7 +35,6 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
 
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 

--- a/src/store/features/nfts/async-thunks/get-collection-data.ts
+++ b/src/store/features/nfts/async-thunks/get-collection-data.ts
@@ -18,7 +18,6 @@ export const getCollectionData = createAsyncThunk<
 
   const jellyInstance = await jellyJsInstanceHandler({
     thunkAPI,
-    collectionId,
     slice: marketplaceSlice,
   });
 

--- a/src/store/features/nfts/async-thunks/get-latest-active-token.ts
+++ b/src/store/features/nfts/async-thunks/get-latest-active-token.ts
@@ -24,7 +24,6 @@ export const getLatestActiveToken = createAsyncThunk<
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 
@@ -87,3 +86,4 @@ export const getLatestActiveToken = createAsyncThunk<
     }
   },
 );
+

--- a/src/store/features/nfts/async-thunks/get-my-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-my-nfts.ts
@@ -13,7 +13,6 @@ export const getMyNFTs = createAsyncThunk<any | undefined, any>(
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 

--- a/src/store/features/nfts/async-thunks/get-search-results.ts
+++ b/src/store/features/nfts/async-thunks/get-search-results.ts
@@ -19,7 +19,6 @@ export const getSearchResults = createAsyncThunk<
 
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
-      collectionId,
       slice: marketplaceSlice,
     });
 
@@ -92,3 +91,4 @@ export const getSearchResults = createAsyncThunk<
     }
   },
 );
+

--- a/src/views/LandingPageView/index.tsx
+++ b/src/views/LandingPageView/index.tsx
@@ -83,11 +83,7 @@ const LandingPageView = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    dispatch(
-      marketplaceActions.getAllCollections(
-        `${config.nftCollectionId}`,
-      ),
-    );
+    dispatch(marketplaceActions.getAllCollections());
 
     dispatch(
       nftsActions.getLatestActiveToken({


### PR DESCRIPTION
## Why?

The jelly js instance creation handler does not require a collection id, it should get it dynamically.

## Demo?

Optionally, provide any screenshot, gif or small video.
