### PR TITLE
chore: 🤖 use generic dip721 actor instead of hard typed collection

### DIFF
--- a/src/store/features/crowns/async-thunks/get-owner-token-identifiers.ts
+++ b/src/store/features/crowns/async-thunks/get-owner-token-identifiers.ts
@@ -19,7 +19,7 @@ export const getOwnerTokenIdentifiers = createAsyncThunk<
     // otherwise creates a new instance
     const actorInstance = await actorInstanceHandler({
       thunkAPI,
-      serviceName: 'crowns',
+      serviceName: 'dip721',
       slice: crownsSlice,
     });
 


### PR DESCRIPTION
## Why?

Use generic actor initialisation argument, as should not hard type collection names on instantiation of DIP-721 like actor

## Demo?

Optionally, provide any screenshot, gif or small video.
