### PR TITLE
fix: 🐛 reset NFTs and filters state to initial on collection Id change

### DIFF
--- a/src/components/collection-overview/collection-overview.tsx
+++ b/src/components/collection-overview/collection-overview.tsx
@@ -8,6 +8,8 @@ import {
   useNFTSStore,
   useTableStore,
   marketplaceActions,
+  nftsActions,
+  filterActions,
 } from '../../store';
 import { FilteredCountChip, LinkButton } from '../core';
 import {
@@ -57,13 +59,18 @@ export const CollectionOverview = () => {
   useEffect(() => {
     if (!collectionId) return;
 
+    // reset state to initial on collection Id change
+    // TODO: handle reset state gracefully if required in anyother places
+    dispatch(nftsActions.reset());
+    dispatch(filterActions.reset());
+
     dispatch(
       marketplaceActions.getCollectionDetails({ collectionId }),
     );
 
     // TODO: Update static data like crowns title, icon
     // by using currentCollectionDetails state
-  }, [id, collectionId]);
+  }, [collectionId]);
 
   return (
     <NftMetadataWrapper>

--- a/src/store/features/filters/filter-slice.ts
+++ b/src/store/features/filters/filter-slice.ts
@@ -67,6 +67,7 @@ export const filterSlice = createSlice({
   name: 'filter',
   initialState,
   reducers: {
+    reset: () => initialState,
     getAllFilters: (
       state,
       action: PayloadAction<FilterTraitsList>,

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -94,6 +94,7 @@ export const nftsSlice = createSlice({
   // `createSlice` will infer the state type from the `initialState` argument
   initialState,
   reducers: {
+    reset: () => initialState,
     setIsNFTSLoading: (state, action: PayloadAction<boolean>) => {
       state.loadingNFTs = action.payload;
       if (state.failedToLoadNFTS) {


### PR DESCRIPTION
## Why?

Reset NFTs and filters state to initial on collection Id change

## How?

- [x] add reset reducer in `nfts` and `filters` store to set state to initial state
- [x] call reset from collection view whenever there is a change in collection Id

## Demo?


https://user-images.githubusercontent.com/40259256/193821328-24be6837-23da-437b-ab74-1799c37c4000.mov


