### PR TITLE
fix: 🐛 show NFT action buttons without refreshing details page

### DIFF
--- a/src/components/nft-details/nft-details.tsx
+++ b/src/components/nft-details/nft-details.tsx
@@ -49,7 +49,7 @@ import useMediaQuery from '../../hooks/use-media-query';
 
 export const NftDetails = () => {
   const dispatch = useAppDispatch();
-  const { loadedNFTS } = useNFTSStore();
+  const { loadedNFTS, loadingNFTDetails } = useNFTSStore();
   const { loadedFiltersList, loadingFilterList } = useFilterStore();
   const { id, collectionId } = useParams();
   const [showNFTActionButtons, setShowNFTActionButtons] =
@@ -164,7 +164,7 @@ export const NftDetails = () => {
               src={nftDetails.location}
             />
             <NFTTraitsContainer>
-              {loadingFilterList ? (
+              {loadingFilterList || loadingNFTDetails ? (
                 <TraitsListLoader />
               ) : (
                 <>

--- a/src/components/nft-details/nft-details.tsx
+++ b/src/components/nft-details/nft-details.tsx
@@ -38,7 +38,6 @@ import {
   getTraitName,
 } from '../../store/features/filters/async-thunks/get-filter-traits';
 import TraitsListLoader from './TraitsListLoader';
-import { roundOffDecimalValue } from '../../utils/nfts';
 import NFTDetailsSkeleton from './nft-details-skeleton';
 import useMediaQuery from '../../hooks/use-media-query';
 
@@ -99,12 +98,16 @@ export const NftDetails = () => {
       parseE8SAmountToWICP(tokenListing?.last_sale?.price));
   const isListed = !!tokenListing?.listing?.time;
   const isMobileScreen = useMediaQuery('(max-width: 850px)');
-  const hasNFTOwnership = owner === plugPrincipal;
 
-  // If not set, shall display the Action buttons?
-  if (!showNFTActionButtons && hasNFTOwnership) {
+  useEffect(() => {
+    // don't show action buttons when details are loading
+    if (loadingNFTDetails || !nftDetails) {
+      setShowNFTActionButtons(false);
+      return;
+    }
+
     setShowNFTActionButtons(true);
-  }
+  }, [loadingNFTDetails, nftDetails]);
 
   useEffect(() => {
     // TODO: handle the error gracefully when there is no id

--- a/src/store/features/filters/async-thunks/get-filter-traits.ts
+++ b/src/store/features/filters/async-thunks/get-filter-traits.ts
@@ -158,10 +158,5 @@ export const extractTraitData = ({
     return nftDetails;
   } catch (error) {
     AppLog.error(error);
-    dispatch(
-      notificationActions.setErrorMessage(
-        'Oops! Failed to get trait data',
-      ),
-    );
   }
 };

--- a/src/store/features/nfts/async-thunks/get-nft-details.ts
+++ b/src/store/features/nfts/async-thunks/get-nft-details.ts
@@ -20,6 +20,8 @@ export const getNFTDetails = createAsyncThunk<
 >('nfts/getNFTDetails', async ({ id, collectionId }, thunkAPI) => {
   const { dispatch } = thunkAPI;
 
+  dispatch(nftsActions.setNFTDetailsLoading());
+
   try {
     const actor = await createActor({
       serviceName: 'dip721',

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -27,6 +27,7 @@ interface NFTSState {
   allNFTs: any[];
   lastIndexValue: number | undefined;
   myNFTIds: string[];
+  loadingNFTDetails: boolean;
 }
 
 // Define the initial state using that type
@@ -44,6 +45,7 @@ const initialState: NFTSState = {
   allNFTs: [],
   lastIndexValue: undefined,
   myNFTIds: [],
+  loadingNFTDetails: true,
 };
 
 export interface LoadedNFTData {
@@ -133,6 +135,8 @@ export const nftsSlice = createSlice({
         (nft) => nft.id === id,
       );
 
+      state.loadingNFTDetails = false;
+
       if (index > -1) {
         state.loadedNFTS[index] = action.payload;
 
@@ -210,6 +214,9 @@ export const nftsSlice = createSlice({
     },
     setMyNFTIds: (state, action: PayloadAction<string[]>) => {
       state.myNFTIds = action.payload;
+    },
+    setNFTDetailsLoading: (state) => {
+      state.loadingNFTDetails = true;
     },
   },
 });


### PR DESCRIPTION
## Why?

Show NFT action buttons without refreshing details page

## How?

- [x] add loader to show traits loader when NFT details are loading
- [x] update logic to show action buttons

## Demo?


https://user-images.githubusercontent.com/40259256/193844256-a3dae1d1-1b1a-4a97-9dd2-1fa2c8294f97.mov


