### PR TITLE
fix: 🐛 conditionally show My NFTs, My offers and My activity details

### DIFF
--- a/src/components/plug/plug-button.tsx
+++ b/src/components/plug/plug-button.tsx
@@ -153,24 +153,28 @@ export const PlugButton = ({
           onMouseLeave={() => setOpenDropdown(false)}
         >
           <div>
-            <ListItem onClick={myOffersHandler}>
-              <Icon icon="offer" paddingRight />
-              <p>{t('translation:buttons.action.myOffers')}</p>
-            </ListItem>
-            <ListItem onClick={myActivityHandler}>
-              <Icon icon="activity" paddingRight />
-              <p>{t('translation:buttons.action.myActivity')}</p>
-            </ListItem>
+            {collectionId && (
+              <>
+                <ListItem onClick={myOffersHandler}>
+                  <Icon icon="offer" paddingRight />
+                  <p>{t('translation:buttons.action.myOffers')}</p>
+                </ListItem>
+                <ListItem onClick={myActivityHandler}>
+                  <Icon icon="activity" paddingRight />
+                  <p>{t('translation:buttons.action.myActivity')}</p>
+                </ListItem>
+                <ListItem onClick={setMyNfts}>
+                  <Icon icon="myNfts" paddingRight />
+                  <p>{t('translation:buttons.action.myNfts')}</p>
+                </ListItem>
+              </>
+            )}
             <ListItem onClick={openSonicURL}>
               <WICPLogo
                 src={wicpImage}
                 alt={t('translation:logoAlts.wicp')}
               />
               <p>{t('translation:buttons.action.getWicp')}</p>
-            </ListItem>
-            <ListItem onClick={setMyNfts}>
-              <Icon icon="myNfts" paddingRight />
-              <p>{t('translation:buttons.action.myNfts')}</p>
             </ListItem>
             <ListItem onClick={disconnectHandler}>
               <Icon icon="disconnect" paddingRight />


### PR DESCRIPTION
## Why?

Conditionally show My NFTs, My offers and My activity details

## How?

- [x] show My NFTs, My offers and My activity details only when collection details present under plug dropdown

## Demo?


https://user-images.githubusercontent.com/40259256/193850591-d008975d-4d2e-4472-9801-7ca44b96cabb.mov


