### PR TITLE
refactor: 💡 use dip20 balance of for headers balance

### DIFF
--- a/src/utils/dip20.ts
+++ b/src/utils/dip20.ts
@@ -1,0 +1,31 @@
+import { Principal } from '@dfinity/principal';
+import { createActor } from '../integrations/actor';
+
+export const getDIP20BalanceOf = async ({
+  userPrincipal,
+}: {
+  userPrincipal: Principal;
+}) => {
+  const actor = await createActor({
+    serviceName: 'wicp',
+  });
+
+  if (!userPrincipal) {
+    console.warn(
+      'Oops! DIP20 balance of failed, user principal is missing',
+    );
+
+    return;
+  }
+
+  const balance = await actor.balanceOf(userPrincipal);
+
+  if (typeof balance === 'undefined') {
+    console.warn('Oops! DIP20 balance of response is unexpected');
+
+    return;
+  }
+
+  return balance;
+};
+


### PR DESCRIPTION
## Why?

 On getPlugWalletBalance lated in (src/integrations/plug/plug.utils.ts), it should use the Actor for wicp and get the balance, this because plug native `requestBalance` will send the request to mainnet

## Demo?

<img width="993" alt="Screenshot 2022-10-05 at 14 34 02" src="https://user-images.githubusercontent.com/236752/194073388-450d0150-70b3-4b36-b983-3888ca08a878.png">
