### PR TITLE
fix: 🐛 make listing price use, num not bigint  for latest jelly

### DIFF
--- a/src/store/features/marketplace/async-thunks/make-listing.ts
+++ b/src/store/features/marketplace/async-thunks/make-listing.ts
@@ -84,6 +84,8 @@ export const makeListing = createAsyncThunk<
         },
       };
 
+      const price = [Number(userListForPrice)];
+
       const MKP_MAKE_LISTING = {
         idl: marketplaceV2IdlFactory,
         canisterId: marketplaceId.toString(),
@@ -97,7 +99,7 @@ export const makeListing = createAsyncThunk<
             fungible_id: [],
             caller: [],
             buyer: [],
-            price: [userListForPrice],
+            price,
           },
         ],
         onSuccess: async (res: any) => {


### PR DESCRIPTION
## Why?

The make listing passing price as bigint causes an error:

```
  Call was rejected:
    Request ID: c4fbd85ae864dedd6e2e81cd3d62b3a155a6e4bb2f785d42e4e9856663b57ee4
    Reject code: 
    Reject text: Canister qoctq-giaaa-aaaaa-aaaea-cai trapped explicitly: Panicked at 'called 
    `Result::unwrap()` on an `Err` value: "Nat -> Nat64 conversion failed"', 
    canisters/marketplace/src/lib.rs:291:76
```

## Demo?

<img width="1031" alt="Screenshot 2022-10-05 at 14 42 16" src="https://user-images.githubusercontent.com/236752/194075134-fca1d30c-838c-4dcd-9fa3-8cf47e7ae825.png">
