### PR TITLE
refactor: 💡 token metadata response property names as text no wasm numerical

### DIFF
--- a/.scripts/generate-mocked-tokens-v2.sh
+++ b/.scripts/generate-mocked-tokens-v2.sh
@@ -103,7 +103,7 @@ printf "👍 Mint process completed!\n\n"
     assetUrl="https://$crownsCertifiedAssetsA.raw.ic0.app/$filename"
 
     # Get some data from the mainnet canister
-    mainnetMetadataResult=($(dfx canister --network ic call --query $crownsNftCanisterId tokenMetadata "($i:nat)" | pcregrep -o1  '3_643_416_556 = "([a-zA-Z]*)"'))
+    mainnetMetadataResult=($(dfx canister --network ic call --query $crownsNftCanisterId tokenMetadata "($i:nat)" | pcregrep -o1  'TextContent = "([a-zA-Z]*)"'))
 
     if [[ ! "$(declare -p mainnetMetadataResult)" =~ "declare -a" ]];
     then


### PR DESCRIPTION
## Why?

The mainnet token metadata now responds with fieldnames which are text not numerical as previous.

## Demo?

Optionally, provide any screenshot, gif or small video.
