### PR TITLE
refactor: 💡get NFT details thunk using jelly-js

### DIFF
--- a/src/components/modals/change-price-modal.tsx
+++ b/src/components/modals/change-price-modal.tsx
@@ -157,6 +157,14 @@ export const ChangePriceModal = ({
           // after a new make listing
           // dispatch(getAllListings());
           setModalStep(ListingStatusCodes.Confirmed);
+          // Update NFT listed for sale in store
+          // on successful listing and closing the modal
+          dispatch(
+            nftsActions.setNFTForSale({
+              id: tokenId as string,
+              amount,
+            }),
+          );
         },
         onFailure: () => {
           setModalStep(ListingStatusCodes.ListingInfo);

--- a/src/components/modals/sell-modal.tsx
+++ b/src/components/modals/sell-modal.tsx
@@ -149,6 +149,15 @@ export const SellModal = ({
           // should pull from the API
           // dispatch(getAllListings());
           setModalStep(ListingStatusCodes.Confirmed);
+
+          // Update NFT listed for sale in store
+          // on successful listing and closing the modal
+          dispatch(
+            nftsActions.setNFTForSale({
+              id: tokenId,
+              amount,
+            }),
+          );
         },
         onFailure: () => {
           setModalStep(ListingStatusCodes.ListingInfo);

--- a/src/components/nft-list/nft-list.tsx
+++ b/src/components/nft-list/nft-list.tsx
@@ -67,6 +67,7 @@ export const NftList = () => {
         count: 25,
         collectionId,
         reverse,
+        page: nextPageNo,
       }),
     );
   };

--- a/src/declarations/legacy.d.ts
+++ b/src/declarations/legacy.d.ts
@@ -11,6 +11,7 @@ export type NFTMetadata = {
   isListed?: boolean;
   owner?: string;
   operator?: string;
+  lastActionTaken?: string;
 };
 
 export interface MetadataPart {

--- a/src/integrations/kyasshu/index.ts
+++ b/src/integrations/kyasshu/index.ts
@@ -16,7 +16,7 @@ import {
 
 export const useNFTSFetcher = () => {
   const dispatch = useAppDispatch();
-  const { collectionId } = useParams();
+  const { collectionId, id } = useParams();
 
   const [currentAbortController, setCurrentAbortController] =
     useState<AbortController>();
@@ -25,7 +25,6 @@ export const useNFTSFetcher = () => {
   const priceValues = usePriceValues();
 
   const { sortBy, reverse } = useFilterStore();
-  const { lastIndexValue } = useNFTSStore();
 
   useUpdateEffect(() => {
     dispatch(nftsActions.clearLoadedNFTS());
@@ -50,10 +49,11 @@ export const useNFTSFetcher = () => {
             : undefined,
           sort: sortBy,
           order: 'd',
-          lastIndex: lastIndexValue,
+          lastIndex: undefined,
           count: 25,
           collectionId,
           reverse,
+          page: 0,
         }),
       );
     }
@@ -66,6 +66,7 @@ export const useNFTSFetcher = () => {
     sortBy,
     status,
     collectionId,
+    id,
   ]);
 };
 

--- a/src/store/features/nfts/async-thunks/get-all-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-all-nfts.ts
@@ -27,6 +27,7 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
       lastIndex,
       count,
       collectionId,
+      page,
     },
     thunkAPI,
   ) => {
@@ -102,13 +103,11 @@ export const getAllNFTs = createAsyncThunk<any | undefined, any>(
         loadedNFTList: extractedNFTSList,
         total: Number(total),
         totalPages: Math.ceil(Number(total) / count),
+        nextPage: page + 1,
       };
 
       if (responseHasLastIndex) {
         actionPayload.lastIndex = Number(responseHasLastIndex) - 1;
-        actionPayload.nextPage =
-          Math.floor(Number(total) / Number(responseHasLastIndex)) +
-          1;
       }
 
       // update store with loaded NFTS details

--- a/src/store/features/nfts/async-thunks/get-nft-details.ts
+++ b/src/store/features/nfts/async-thunks/get-nft-details.ts
@@ -125,7 +125,6 @@ export const getNFTDetails = createAsyncThunk<
       lastSaleTime: nftData?.lastSaleTime,
       rendered: true,
     };
-
     // update store with loaded NFT details
     dispatch(nftsActions.setLoadedNFTDetails(nftDetails));
   } catch (error: any) {

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -10,6 +10,7 @@ import {
   getSearchResults,
   getLatestActiveToken,
 } from './async-thunks';
+import { parseAmountToE8S } from '../../../utils/formatters';
 
 // Define a type for the slice state
 interface NFTSState {
@@ -158,7 +159,8 @@ export const nftsSlice = createSlice({
       if (index < 0) return;
 
       state.loadedNFTS[index].isListed = true;
-      state.loadedNFTS[index].price = amount;
+      state.loadedNFTS[index].price =
+        parseAmountToE8S(amount).toString();
     },
     // TODO: Do not change the state manually,
     // if required query from the API and update the global state
@@ -178,6 +180,8 @@ export const nftsSlice = createSlice({
       if (index < 0) return;
 
       state.loadedNFTS[index].isListed = false;
+      state.loadedNFTS[index].price = '';
+      state.loadedNFTS[index].lastActionTaken = '';
     },
     acceptNFTOffer: (
       state,

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -109,7 +109,11 @@ export const nftsSlice = createSlice({
         action.payload;
       state.loadingNFTs = false;
       state.lastIndexValue = lastIndex;
-      state.loadedNFTS.push(...loadedNFTList);
+      if (nextPage === 1) {
+        state.loadedNFTS = loadedNFTList;
+      } else {
+        state.loadedNFTS.push(...loadedNFTList);
+      }
 
       if (nextPage && totalPages) {
         if (nextPage < totalPages) {
@@ -159,6 +163,7 @@ export const nftsSlice = createSlice({
       if (index < 0) return;
 
       state.loadedNFTS[index].isListed = true;
+      state.loadedNFTS[index].lastActionTaken = 'for sale';
       state.loadedNFTS[index].price =
         parseAmountToE8S(amount).toString();
     },


### PR DESCRIPTION
## Why?

Update `get nft details` thunk to fetch NFT details on page refresh and to retain state when user switches back from details page to list page

## How?

- [x] use `getNFTs` from `jelly-js` to avoid 404 not found
- [x] update response data coming from `getNFTs` to maintain same state across Listing and details page
- [x] update pagination logic to update NFT values in List page when user switches from details page

## Demo?


https://user-images.githubusercontent.com/40259256/195305512-fc23db1e-b92f-4f50-b797-15034fd2e89a.mov




https://user-images.githubusercontent.com/40259256/195307665-c0dfa6bc-bf5d-4de6-ba02-d7ea4c9b0339.mp4

