### PR TITLE
fix: 🐛 handle My NFTs when not connected to plug

### DIFF
--- a/src/store/features/nfts/async-thunks/get-my-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-my-nfts.ts
@@ -109,6 +109,7 @@ export const getMyNFTs = createAsyncThunk<any | undefined, any>(
 
         // update store with loaded NFTS details
         dispatch(nftsActions.setLoadedNFTS(actionPayload));
+        dispatch(nftsActions.setNFTsTotalCount(userNFTIds.length));
       }
 
       const myNFTIds = userNFTIds || [];
@@ -125,6 +126,8 @@ export const getMyNFTs = createAsyncThunk<any | undefined, any>(
       return myNFTIds;
     } catch (err) {
       AppLog.error(err);
+
+      dispatch(nftsActions.setIsNFTSLoading(false));
     }
   },
 );

--- a/src/store/features/nfts/async-thunks/get-my-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-my-nfts.ts
@@ -13,14 +13,15 @@ export const getMyNFTs = createAsyncThunk<any | undefined, any>(
     { collectionId, shouldFetchUserTokenIdsAlone },
     thunkAPI,
   ) => {
+    const { dispatch } = thunkAPI;
+
+    dispatch(nftsActions.setNFTsTotalCount(0));
     // Checks if an actor instance exists already
     // otherwise creates a new instance
     const jellyInstance = await jellyJsInstanceHandler({
       thunkAPI,
       slice: marketplaceSlice,
     });
-
-    const { dispatch } = thunkAPI;
 
     if (!shouldFetchUserTokenIdsAlone) {
       // set loading NFTS state to true
@@ -127,6 +128,7 @@ export const getMyNFTs = createAsyncThunk<any | undefined, any>(
     } catch (err) {
       AppLog.error(err);
 
+      dispatch(nftsActions.setNFTsTotalCount(0));
       dispatch(nftsActions.setIsNFTSLoading(false));
     }
   },

--- a/src/store/features/nfts/nfts-slice.ts
+++ b/src/store/features/nfts/nfts-slice.ts
@@ -236,6 +236,9 @@ export const nftsSlice = createSlice({
     setNFTDetailsLoading: (state) => {
       state.loadingNFTDetails = true;
     },
+    setNFTsTotalCount: (state, action: PayloadAction<number>) => {
+      state.totalNFTSCount = action.payload;
+    },
   },
 });
 


### PR DESCRIPTION
## Why?

Handle My NFTs when not connected to plug

## How?

- [x] turn off loader when user not connected to plug
- [x] update total NFTs count when user clicks My NFTs

## Demo?

![Screenshot 2022-10-18 at 5 15 31 PM](https://user-images.githubusercontent.com/40259256/196420823-8710b81a-b705-4fa8-95c5-a4f57cd7038f.png)

