### PR TITLE
chore: 🤖 show fee tooltips in modals

### DIFF
--- a/src/components/core/tooltip/tooltip.tsx
+++ b/src/components/core/tooltip/tooltip.tsx
@@ -15,8 +15,27 @@ export type TooltipProps = {
 export const Tooltip = ({ children, text }: TooltipProps) => {
   const [, themeObject] = useTheme();
 
+  const handleTooltipOpen = (status: boolean) => {
+    const applicationBody = document.querySelector('body');
+
+    if (!applicationBody) return;
+
+    if (status) {
+      applicationBody?.classList.add('tooltip-open');
+
+      return;
+    }
+
+    if (applicationBody?.classList.contains('tooltip-open')) {
+      applicationBody?.classList.remove('tooltip-open');
+    }
+  };
+
   return (
-    <TooltipPrimitive.Root delayDuration={300}>
+    <TooltipPrimitive.Root
+      delayDuration={300}
+      onOpenChange={handleTooltipOpen}
+    >
       <TooltipPrimitive.Trigger asChild>
         <div>{children}</div>
       </TooltipPrimitive.Trigger>

--- a/src/components/modals/accept-offer-modal.tsx
+++ b/src/components/modals/accept-offer-modal.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { ActionButton, Completed } from '../core';
+import { ActionButton, Completed, Tooltip } from '../core';
 import wicpIcon from '../../assets/wicp.svg';
 import {
   AcceptOfferModalTrigger,
@@ -253,7 +253,11 @@ export const AcceptOfferModal = ({
                       <FeeLabel>
                         {t('translation:modals.labels.protocolFee')}
                       </FeeLabel>
-                      <InfoIcon icon="info" />
+                      <Tooltip
+                        text={t('translation:tooltip.protocolFee')}
+                      >
+                        <InfoIcon icon="info" />
+                      </Tooltip>
                     </FeeLabelContainer>
                     <FeePercent>
                       {t(
@@ -266,7 +270,11 @@ export const AcceptOfferModal = ({
                       <FeeLabel>
                         {t('translation:modals.labels.collectionFee')}
                       </FeeLabel>
-                      <InfoIcon icon="info" />
+                      <Tooltip
+                        text={t('translation:tooltip.collectionFee')}
+                      >
+                        <InfoIcon icon="info" />
+                      </Tooltip>
                     </FeeLabelContainer>
                     <FeePercent>
                       {t(

--- a/src/components/modals/change-price-modal.tsx
+++ b/src/components/modals/change-price-modal.tsx
@@ -8,6 +8,7 @@ import {
   ModalInput,
   Completed,
   NftCard,
+  Tooltip,
 } from '../core';
 import {
   ChangePriceModalTrigger,
@@ -286,7 +287,11 @@ export const ChangePriceModal = ({
                         <FeeLabel>
                           {t('translation:modals.labels.protocolFee')}
                         </FeeLabel>
-                        <InfoIcon icon="info" />
+                        <Tooltip
+                          text={t('translation:tooltip.protocolFee')}
+                        >
+                          <InfoIcon icon="info" />
+                        </Tooltip>
                       </FeeLabelContainer>
                       <FeePercent>
                         {t(
@@ -301,7 +306,13 @@ export const ChangePriceModal = ({
                             'translation:modals.labels.collectionFee',
                           )}
                         </FeeLabel>
-                        <InfoIcon icon="info" />
+                        <Tooltip
+                          text={t(
+                            'translation:tooltip.collectionFee',
+                          )}
+                        >
+                          <InfoIcon icon="info" />
+                        </Tooltip>
                       </FeeLabelContainer>
                       <FeePercent>
                         {t(

--- a/src/components/modals/sell-modal.tsx
+++ b/src/components/modals/sell-modal.tsx
@@ -8,6 +8,7 @@ import {
   ModalInput,
   Completed,
   NftCard,
+  Tooltip,
 } from '../core';
 import {
   SellModalTrigger,
@@ -277,7 +278,11 @@ export const SellModal = ({
                         <FeeLabel>
                           {t('translation:modals.labels.protocolFee')}
                         </FeeLabel>
-                        <InfoIcon icon="info" />
+                        <Tooltip
+                          text={t('translation:tooltip.protocolFee')}
+                        >
+                          <InfoIcon icon="info" />
+                        </Tooltip>
                       </FeeLabelContainer>
                       <FeePercent>
                         {t(
@@ -292,7 +297,13 @@ export const SellModal = ({
                             'translation:modals.labels.collectionFee',
                           )}
                         </FeeLabel>
-                        <InfoIcon icon="info" />
+                        <Tooltip
+                          text={t(
+                            'translation:tooltip.collectionFee',
+                          )}
+                        >
+                          <InfoIcon icon="info" />
+                        </Tooltip>
                       </FeeLabelContainer>
                       <FeePercent>
                         {t(

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -327,7 +327,9 @@
     "retryMessage": "click here to withdraw."
   },
   "tooltip": {
-    "disabledBuyNowText": "Oops! Can't be purchased, possibly because token was transferred outside Jelly marketplace to a new wallet"
+    "disabledBuyNowText": "Oops! Can't be purchased, possibly because token was transferred outside Jelly marketplace to a new wallet",
+    "protocolFee": "Standard 1% service fee on all NFT trades",
+    "collectionFee": "Royalties granted to collection creators on each NFT sale"
   },
   "landingPage": {
     "introTitle": "Sweet NFT Tools & Infra ✨",

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -25,6 +25,8 @@ export const portalZIndexGlobals = globalCss({
     '& [data-radix-portal].above-nav': {
       zIndex: '4 !important',
     },
+    '&.tooltip-open [data-radix-portal]': {
+      zIndex: '30 !important',
+    },
   },
 });
-


### PR DESCRIPTION
## Why?

Show protocol and collection fees tooltips in modals

## How?

- [x] update tooltip styles to render in modals
- [x] add `protocol fee` & `collection fee` in locales
- [x] show fees `tooltip` in `sell modal`, `change price modal` & `accept offer modal`

## Tickets?

- [Issue 55](https://github.com/Psychedelic/jelly/issues/55)

## Demo?

Protocol Fee:

![protocol-fee](https://user-images.githubusercontent.com/40259256/196863253-2700cf7d-05b2-4836-8b06-6b72adce93ac.png)

Collection Fee:

![collection-fee](https://user-images.githubusercontent.com/40259256/196863298-e0327dc7-e329-42b2-8dad-f0c5da7ceefe.png)

