### PR TITLE
chore: 🤖 add tooltip to show plug available balance

### DIFF
--- a/src/components/core/tooltip/balance-tooltip.tsx
+++ b/src/components/core/tooltip/balance-tooltip.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { StyledContent, StyledArrow } from './styles';
+import { useTheme } from '../../../hooks';
+import {
+  formatAmountAbbreviation,
+  formatAmountDecimals,
+} from '../../../utils/formatters';
+
+/* --------------------------------------------------------------------------
+ * Balance Tooltip Component
+ * --------------------------------------------------------------------------*/
+
+export type BalanceTooltipProps = {
+  text?: string;
+};
+
+export const BalanceTooltip = ({ text }: BalanceTooltipProps) => {
+  const [, themeObject] = useTheme();
+
+  const handleTooltipOpen = (status: boolean) => {
+    const applicationBody = document.querySelector('body');
+
+    if (!applicationBody) return;
+
+    if (status) {
+      applicationBody?.classList.add('tooltip-open');
+
+      return;
+    }
+
+    if (applicationBody?.classList.contains('tooltip-open')) {
+      applicationBody?.classList.remove('tooltip-open');
+    }
+  };
+
+  const [triggerText, contentText] = useMemo(() => {
+    const content = formatAmountDecimals(String(text));
+    const trigger = formatAmountAbbreviation(content);
+    return [trigger, content];
+  }, [text]);
+
+  return (
+    <TooltipPrimitive.Root
+      delayDuration={300}
+      onOpenChange={handleTooltipOpen}
+    >
+      <TooltipPrimitive.Trigger asChild>
+        <span>{triggerText}</span>
+      </TooltipPrimitive.Trigger>
+      {text && contentText && contentText.length > 3 && (
+        <StyledContent sideOffset={5} className={themeObject}>
+          {contentText}
+          <StyledArrow />
+        </StyledContent>
+      )}
+    </TooltipPrimitive.Root>
+  );
+};

--- a/src/components/core/tooltip/index.ts
+++ b/src/components/core/tooltip/index.ts
@@ -1,1 +1,2 @@
 export * from './tooltip';
+export * from './balance-tooltip';

--- a/src/components/plug/plug-balance.tsx
+++ b/src/components/plug/plug-balance.tsx
@@ -16,7 +16,7 @@ import { AppLog } from '../../utils/log';
 import wicpImage from '../../assets/wicp.svg';
 import { roundOffDecimalValue } from '../../utils/nfts';
 import { getDIP20BalanceOf } from '../../utils/dip20';
-import { NumberTooltip } from '../number-tooltip';
+import { BalanceTooltip } from '../core/tooltip';
 
 const PlugBalance = () => {
   const { t } = useTranslation();
@@ -63,9 +63,7 @@ const PlugBalance = () => {
         alt={t('translation:logoAlts.wicp')}
       />
       {wicpBalance !== '' && !loadingWicpBalance ? (
-        <NumberTooltip>
-          {wicpBalance}
-        </NumberTooltip>
+        <BalanceTooltip text={wicpBalance} />
       ) : (
         <SpinnerIcon />
       )}


### PR DESCRIPTION
## Why?

Add tooltip to show plug available balance

## How?

- [x] add `balance tooltip` component
- [x] use `balance tooltip` component in plug component to show balance in tooltip when balance is greater than 3 digits

## Demo?

![Screenshot 2022-10-21 at 11 17 40 AM](https://user-images.githubusercontent.com/40259256/197122473-6d8f979c-c036-47e1-be08-ac9881bfd206.png)

