### PR TITLE
chore: 🤖 change plug status text from loading when verifying

### DIFF
--- a/src/components/plug/plug.tsx
+++ b/src/components/plug/plug.tsx
@@ -144,7 +144,7 @@ export const Plug = () => {
         <PlugButton
           handleConnect={handleConnect}
           isMobileScreen={isMobileScreen}
-          text={t('translation:buttons.action.loading')}
+          text={t('translation:buttons.action.connectToPlug')}
           isConnected={isConnected}
           principalId={principalId}
         />


### PR DESCRIPTION
## Why?

Change plug status text from loading when plug is locked and status is verifying

## Tickets?

- [Bug fixes](https://github.com/Psychedelic/jelly/issues/73)

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [x] All code formatting pass
- [x] All lints pass

## Demo?

https://user-images.githubusercontent.com/51888121/197790127-1a07a697-ed56-4493-b881-53248b905db3.mov
