### PR TITLE
fix: 🐛 show updated My NFT card details after listing (My NFT's filter)

### DIFF
--- a/src/store/features/nfts/async-thunks/get-my-nfts.ts
+++ b/src/store/features/nfts/async-thunks/get-my-nfts.ts
@@ -140,6 +140,12 @@ export const getMyNFTs = createAsyncThunk<any | undefined, any>(
               owner: nft?.owner,
               operator: nft?.operator,
               rendered: true,
+              lastActionTaken: nft?.lastActionTaken,
+              listing: nft?.listing,
+              lastListingTime: nft?.lastListingTime,
+              offers: nft?.offers,
+              lastOfferTime: nft?.lastOfferTime,
+              lastSaleTime: nft?.lastSaleTime,
             };
             return metadata;
           });
@@ -182,6 +188,12 @@ export const getMyNFTs = createAsyncThunk<any | undefined, any>(
               owner: nft?.owner,
               operator: nft?.operator,
               rendered: true,
+              lastActionTaken: nft?.lastActionTaken,
+              listing: nft?.listing,
+              lastListingTime: nft?.lastListingTime,
+              offers: nft?.offers,
+              lastOfferTime: nft?.lastOfferTime,
+              lastSaleTime: nft?.lastSaleTime,
             };
             return metadata;
           });


### PR DESCRIPTION
## Why?

Show updated My NFT card details after listing (My NFT's filter)

## How?

- [x] update extracted My NFT card details to show list/sale/offer details when user applied `My NFTs` filter

## Demo?

<img width="1026" alt="Screenshot 2022-10-31 at 1 28 15 PM" src="https://user-images.githubusercontent.com/40259256/198960283-ab122c43-e42d-4b2d-b092-8c322c40d783.png">

